### PR TITLE
Partenza/demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bloxroute/solana-trader-client-ts",
-    "version": "2.2.6",
+    "version": "2.2.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bloxroute/solana-trader-client-ts",
-            "version": "2.2.6",
+            "version": "2.2.7",
             "license": "MIT",
             "dependencies": {
                 "@grpc/grpc-js": "^1.10.2",
@@ -15,7 +15,10 @@
                 "axios": "1.1.2",
                 "bs58": "^5.0.0",
                 "dotenv": "^16.0.1",
+                "figlet": "^1.8.1",
                 "google-protobuf": "^3.20.1",
+                "gradient-string": "^3.0.0",
+                "inquirer": "^12.5.2",
                 "isomorphic-ws": "5.0.0",
                 "np": "^10.0.6",
                 "pbkit": "^0.0.53",
@@ -25,6 +28,7 @@
                 "ws": "^8.8.0"
             },
             "devDependencies": {
+                "@bloxroute/solana-trader-client-ts": "2.2.7",
                 "@protobuf-ts/plugin": "^2.7.0",
                 "@types/google-protobuf": "^3.15.6",
                 "@types/jest": "^29.5.14",
@@ -573,6 +577,28 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "node_modules/@bloxroute/solana-trader-client-ts": {
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/@bloxroute/solana-trader-client-ts/-/solana-trader-client-ts-2.2.7.tgz",
+            "integrity": "sha512-I8He1YTxaqNjH9e3A9y/JraiJDlMqwtv9TguQ4lFA0COJK4RMcBR5poLyCglTPpnrzKnEJgXiNHTgK+/5JsBFA==",
+            "dev": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.10.2",
+                "@pbkit/grpc-client": "^0.0.3",
+                "@solana/web3.js": "1.73.2",
+                "axios": "1.1.2",
+                "bs58": "^5.0.0",
+                "dotenv": "^16.0.1",
+                "google-protobuf": "^3.20.1",
+                "isomorphic-ws": "5.0.0",
+                "np": "^10.0.6",
+                "pbkit": "^0.0.53",
+                "ts-node": "^10.8.1",
+                "typescript": "^4.7.4",
+                "websocket-iterator": "^1.0.1",
+                "ws": "^8.8.0"
+            }
+        },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -936,22 +962,61 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
+            "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-            "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.3.2",
-                "globals": "^13.15.0",
+                "espree": "^9.6.0",
+                "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
                 "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+            "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+            "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
@@ -1014,41 +1079,452 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-            "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+            "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "@humanwhocodes/object-schema": "^2.0.3",
+                "debug": "^4.3.1",
+                "minimatch": "^3.0.5"
             },
             "engines": {
                 "node": ">=10.10.0"
             }
         },
-        "node_modules/@humanwhocodes/gitignore-to-minimatch": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-            "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
+            "engines": {
+                "node": ">=12.22"
+            },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+            "deprecated": "Use @eslint/object-schema instead",
             "dev": true
         },
-        "node_modules/@inquirer/figures": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.3.tgz",
-            "integrity": "sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw==",
+        "node_modules/@inquirer/checkbox": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
+            "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "yoctocolors-cjs": "^2.1.2"
+            },
             "engines": {
                 "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/checkbox/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/checkbox/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/confirm": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
+            "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/core": {
+            "version": "10.1.10",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
+            "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+            "dependencies": {
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "cli-width": "^4.1.0",
+                "mute-stream": "^2.0.0",
+                "signal-exit": "^4.1.0",
+                "wrap-ansi": "^6.2.0",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/editor": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
+            "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6",
+                "external-editor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/expand": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
+            "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/figures": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+            "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/input": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
+            "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/number": {
+            "version": "3.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.12.tgz",
+            "integrity": "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/password": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
+            "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/password/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/password/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/prompts": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.1.tgz",
+            "integrity": "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==",
+            "dependencies": {
+                "@inquirer/checkbox": "^4.1.5",
+                "@inquirer/confirm": "^5.1.9",
+                "@inquirer/editor": "^4.2.10",
+                "@inquirer/expand": "^4.0.12",
+                "@inquirer/input": "^4.1.9",
+                "@inquirer/number": "^3.0.12",
+                "@inquirer/password": "^4.0.12",
+                "@inquirer/rawlist": "^4.0.12",
+                "@inquirer/search": "^3.0.12",
+                "@inquirer/select": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/rawlist": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.12.tgz",
+            "integrity": "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/search": {
+            "version": "3.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
+            "integrity": "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/select": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.1.tgz",
+            "integrity": "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==",
+            "dependencies": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/select/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/select/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/type": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
+            "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -2176,6 +2652,11 @@
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true
         },
+        "node_modules/@types/tinycolor2": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+            "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw=="
+        },
         "node_modules/@types/ws": {
             "version": "8.5.3",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
@@ -2384,6 +2865,12 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+            "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+            "dev": true
+        },
         "node_modules/@yarnpkg/fslib": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.7.0.tgz",
@@ -2409,9 +2896,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.14.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3352,11 +3839,11 @@
             }
         },
         "node_modules/cli-width": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
             "engines": {
-                "node": ">= 10"
+                "node": ">= 12"
             }
         },
         "node_modules/cliui": {
@@ -4003,50 +4490,50 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-            "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+            "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.3.0",
-                "@humanwhocodes/config-array": "^0.10.4",
-                "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
-                "ajv": "^6.10.0",
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.1",
+                "@humanwhocodes/config-array": "^0.13.0",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.3",
-                "esquery": "^1.4.0",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
+                "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^6.0.1",
-                "globals": "^13.15.0",
-                "globby": "^11.1.0",
-                "grapheme-splitter": "^1.0.4",
+                "glob-parent": "^6.0.2",
+                "globals": "^13.19.0",
+                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
+                "is-path-inside": "^3.0.3",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
+                "optionator": "^0.9.3",
                 "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
+                "text-table": "^0.2.0"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
@@ -4132,18 +4619,21 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -4151,6 +4641,9 @@
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/estraverse": {
@@ -4162,15 +4655,24 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/eslint/node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/espree": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-            "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.8.0",
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4193,9 +4695,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -4453,6 +4955,17 @@
             "dev": true,
             "dependencies": {
                 "bser": "2.1.1"
+            }
+        },
+        "node_modules/figlet": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.1.tgz",
+            "integrity": "sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==",
+            "bin": {
+                "figlet": "bin/index.js"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
             }
         },
         "node_modules/figures": {
@@ -4749,9 +5262,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.17.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-            "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -4828,10 +5341,33 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
-        "node_modules/grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+        "node_modules/gradient-string": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-3.0.0.tgz",
+            "integrity": "sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==",
+            "dependencies": {
+                "chalk": "^5.3.0",
+                "tinygradient": "^1.1.5"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/gradient-string/node_modules/chalk": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
         "node_modules/has-ansi": {
@@ -5159,26 +5695,28 @@
             }
         },
         "node_modules/inquirer": {
-            "version": "7.3.3",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-            "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+            "version": "12.5.2",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.5.2.tgz",
+            "integrity": "sha512-qoDk/vdSTIaXNXAoNnlg7ubexpJfUo7t8GT2vylxvE49BrLhToFuPPdMViidG2boHV7+AcP1TCkJs/+PPoF2QQ==",
             "dependencies": {
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.1.0",
-                "cli-cursor": "^3.1.0",
-                "cli-width": "^3.0.0",
-                "external-editor": "^3.0.3",
-                "figures": "^3.0.0",
-                "lodash": "^4.17.19",
-                "mute-stream": "0.0.8",
-                "run-async": "^2.4.0",
-                "rxjs": "^6.6.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0",
-                "through": "^2.3.6"
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/prompts": "^7.4.1",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "mute-stream": "^2.0.0",
+                "run-async": "^3.0.0",
+                "rxjs": "^7.8.2"
             },
             "engines": {
-                "node": ">=8.0.0"
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/inquirer-autosubmit-prompt": {
@@ -5360,72 +5898,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/inquirer/node_modules/cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+        "node_modules/inquirer/node_modules/run-async": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+            "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
             "dependencies": {
-                "restore-cursor": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=8"
+                "tslib": "^2.1.0"
             }
         },
-        "node_modules/inquirer/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/inquirer/node_modules/figures": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-            "dependencies": {
-                "escape-string-regexp": "^1.0.5"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/inquirer/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/inquirer/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/inquirer/node_modules/restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
+        "node_modules/inquirer/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/inquirer/node_modules/type-fest": {
             "version": "0.21.3",
@@ -6763,6 +7255,134 @@
                 "node": ">=6"
             }
         },
+        "node_modules/listr-input/node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/listr-input/node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/listr-input/node_modules/cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/listr-input/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/listr-input/node_modules/figures": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/listr-input/node_modules/inquirer": {
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+            "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+            "dependencies": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.19",
+                "mute-stream": "0.0.8",
+                "run-async": "^2.4.0",
+                "rxjs": "^6.6.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/listr-input/node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/listr-input/node_modules/mute-stream": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+        },
+        "node_modules/listr-input/node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/listr-input/node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/listr-input/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/listr-silent-renderer": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
@@ -7255,9 +7875,12 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/mute-stream": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+            "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -7425,14 +8048,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/np/node_modules/cli-width": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-            "engines": {
-                "node": ">= 12"
             }
         },
         "node_modules/np/node_modules/cosmiconfig": {
@@ -7727,9 +8342,9 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
@@ -7737,7 +8352,7 @@
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
                 "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "word-wrap": "^1.2.5"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -8221,9 +8836,9 @@
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -9003,6 +9618,20 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
         },
+        "node_modules/tinycolor2": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+        },
+        "node_modules/tinygradient": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
+            "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+            "dependencies": {
+                "@types/tinycolor2": "^1.4.0",
+                "tinycolor2": "^1.0.0"
+            }
+        },
         "node_modules/tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -9410,12 +10039,6 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/v8-compile-cache": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-            "dev": true
-        },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -9576,9 +10199,9 @@
             }
         },
         "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -10117,6 +10740,28 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "@bloxroute/solana-trader-client-ts": {
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/@bloxroute/solana-trader-client-ts/-/solana-trader-client-ts-2.2.7.tgz",
+            "integrity": "sha512-I8He1YTxaqNjH9e3A9y/JraiJDlMqwtv9TguQ4lFA0COJK4RMcBR5poLyCglTPpnrzKnEJgXiNHTgK+/5JsBFA==",
+            "dev": true,
+            "requires": {
+                "@grpc/grpc-js": "^1.10.2",
+                "@pbkit/grpc-client": "^0.0.3",
+                "@solana/web3.js": "1.73.2",
+                "axios": "1.1.2",
+                "bs58": "^5.0.0",
+                "dotenv": "^16.0.1",
+                "google-protobuf": "^3.20.1",
+                "isomorphic-ws": "5.0.0",
+                "np": "^10.0.6",
+                "pbkit": "^0.0.53",
+                "ts-node": "^10.8.1",
+                "typescript": "^4.7.4",
+                "websocket-iterator": "^1.0.1",
+                "ws": "^8.8.0"
+            }
+        },
         "@cspotcode/source-map-support": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -10279,22 +10924,43 @@
             "dev": true,
             "optional": true
         },
+        "@eslint-community/eslint-utils": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
+            "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^3.4.3"
+            }
+        },
+        "@eslint-community/regexpp": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+            "dev": true
+        },
         "@eslint/eslintrc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-            "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.3.2",
-                "globals": "^13.15.0",
+                "espree": "^9.6.0",
+                "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
                 "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             }
+        },
+        "@eslint/js": {
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+            "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+            "dev": true
         },
         "@grpc/grpc-js": {
             "version": "1.10.2",
@@ -10343,32 +11009,247 @@
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-            "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
             "dev": true,
             "requires": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "@humanwhocodes/object-schema": "^2.0.3",
+                "debug": "^4.3.1",
+                "minimatch": "^3.0.5"
             }
         },
-        "@humanwhocodes/gitignore-to-minimatch": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-            "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+        "@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true
         },
         "@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "dev": true
         },
+        "@inquirer/checkbox": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
+            "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+                    "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "requires": {
+                        "type-fest": "^0.21.3"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.21.3",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                }
+            }
+        },
+        "@inquirer/confirm": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
+            "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6"
+            }
+        },
+        "@inquirer/core": {
+            "version": "10.1.10",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
+            "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+            "requires": {
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "cli-width": "^4.1.0",
+                "mute-stream": "^2.0.0",
+                "signal-exit": "^4.1.0",
+                "wrap-ansi": "^6.2.0",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+                    "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "requires": {
+                        "type-fest": "^0.21.3"
+                    }
+                },
+                "signal-exit": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+                    "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+                },
+                "type-fest": {
+                    "version": "0.21.3",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@inquirer/editor": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
+            "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6",
+                "external-editor": "^3.1.0"
+            }
+        },
+        "@inquirer/expand": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
+            "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6",
+                "yoctocolors-cjs": "^2.1.2"
+            }
+        },
         "@inquirer/figures": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.3.tgz",
-            "integrity": "sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw=="
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+            "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw=="
+        },
+        "@inquirer/input": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
+            "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6"
+            }
+        },
+        "@inquirer/number": {
+            "version": "3.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.12.tgz",
+            "integrity": "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6"
+            }
+        },
+        "@inquirer/password": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
+            "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+                    "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "requires": {
+                        "type-fest": "^0.21.3"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.21.3",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                }
+            }
+        },
+        "@inquirer/prompts": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.1.tgz",
+            "integrity": "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==",
+            "requires": {
+                "@inquirer/checkbox": "^4.1.5",
+                "@inquirer/confirm": "^5.1.9",
+                "@inquirer/editor": "^4.2.10",
+                "@inquirer/expand": "^4.0.12",
+                "@inquirer/input": "^4.1.9",
+                "@inquirer/number": "^3.0.12",
+                "@inquirer/password": "^4.0.12",
+                "@inquirer/rawlist": "^4.0.12",
+                "@inquirer/search": "^3.0.12",
+                "@inquirer/select": "^4.1.1"
+            }
+        },
+        "@inquirer/rawlist": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.12.tgz",
+            "integrity": "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/type": "^3.0.6",
+                "yoctocolors-cjs": "^2.1.2"
+            }
+        },
+        "@inquirer/search": {
+            "version": "3.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
+            "integrity": "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "yoctocolors-cjs": "^2.1.2"
+            }
+        },
+        "@inquirer/select": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.1.tgz",
+            "integrity": "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==",
+            "requires": {
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/figures": "^1.0.11",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "yoctocolors-cjs": "^2.1.2"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+                    "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "requires": {
+                        "type-fest": "^0.21.3"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.21.3",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                }
+            }
+        },
+        "@inquirer/type": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
+            "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+            "requires": {}
         },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -11290,6 +12171,11 @@
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true
         },
+        "@types/tinycolor2": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+            "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw=="
+        },
         "@types/ws": {
             "version": "8.5.3",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
@@ -11409,6 +12295,12 @@
                 "eslint-visitor-keys": "^3.3.0"
             }
         },
+        "@ungap/structured-clone": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+            "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+            "dev": true
+        },
         "@yarnpkg/fslib": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-2.7.0.tgz",
@@ -11428,9 +12320,9 @@
             }
         },
         "acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+            "version": "8.14.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="
         },
         "acorn-jsx": {
             "version": "5.3.2",
@@ -12073,9 +12965,9 @@
             }
         },
         "cli-width": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
         },
         "cliui": {
             "version": "8.0.1",
@@ -12522,56 +13414,55 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-            "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.3.0",
-                "@humanwhocodes/config-array": "^0.10.4",
-                "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
-                "ajv": "^6.10.0",
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.1",
+                "@humanwhocodes/config-array": "^0.13.0",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.3",
-                "esquery": "^1.4.0",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
+                "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^6.0.1",
-                "globals": "^13.15.0",
-                "globby": "^11.1.0",
-                "grapheme-splitter": "^1.0.4",
+                "glob-parent": "^6.0.2",
+                "globals": "^13.19.0",
+                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
+                "is-path-inside": "^3.0.3",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
+                "optionator": "^0.9.3",
                 "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
+                "text-table": "^0.2.0"
             },
             "dependencies": {
                 "eslint-scope": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-                    "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+                    "version": "7.2.2",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+                    "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
                     "dev": true,
                     "requires": {
                         "esrecurse": "^4.3.0",
@@ -12582,6 +13473,12 @@
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
                     "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+                    "dev": true
+                },
+                "is-path-inside": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+                    "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
                     "dev": true
                 }
             }
@@ -12630,20 +13527,20 @@
             }
         },
         "eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true
         },
         "espree": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-            "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "requires": {
-                "acorn": "^8.8.0",
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.1"
             }
         },
         "esprima": {
@@ -12653,9 +13550,9 @@
             "dev": true
         },
         "esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "requires": {
                 "estraverse": "^5.1.0"
@@ -12850,6 +13747,11 @@
             "requires": {
                 "bser": "2.1.1"
             }
+        },
+        "figlet": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.1.tgz",
+            "integrity": "sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg=="
         },
         "figures": {
             "version": "2.0.0",
@@ -13055,9 +13957,9 @@
             }
         },
         "globals": {
-            "version": "13.17.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-            "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -13112,10 +14014,26 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
-        "grapheme-splitter": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+        "gradient-string": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-3.0.0.tgz",
+            "integrity": "sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==",
+            "requires": {
+                "chalk": "^5.3.0",
+                "tinygradient": "^1.1.5"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+                    "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="
+                }
+            }
+        },
+        "graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
         "has-ansi": {
@@ -13339,23 +14257,17 @@
             "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="
         },
         "inquirer": {
-            "version": "7.3.3",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-            "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+            "version": "12.5.2",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.5.2.tgz",
+            "integrity": "sha512-qoDk/vdSTIaXNXAoNnlg7ubexpJfUo7t8GT2vylxvE49BrLhToFuPPdMViidG2boHV7+AcP1TCkJs/+PPoF2QQ==",
             "requires": {
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.1.0",
-                "cli-cursor": "^3.1.0",
-                "cli-width": "^3.0.0",
-                "external-editor": "^3.0.3",
-                "figures": "^3.0.0",
-                "lodash": "^4.17.19",
-                "mute-stream": "0.0.8",
-                "run-async": "^2.4.0",
-                "rxjs": "^6.6.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0",
-                "through": "^2.3.6"
+                "@inquirer/core": "^10.1.10",
+                "@inquirer/prompts": "^7.4.1",
+                "@inquirer/type": "^3.0.6",
+                "ansi-escapes": "^4.3.2",
+                "mute-stream": "^2.0.0",
+                "run-async": "^3.0.0",
+                "rxjs": "^7.8.2"
             },
             "dependencies": {
                 "ansi-escapes": {
@@ -13366,48 +14278,23 @@
                         "type-fest": "^0.21.3"
                     }
                 },
-                "cli-cursor": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-                    "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+                "run-async": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+                    "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q=="
+                },
+                "rxjs": {
+                    "version": "7.8.2",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+                    "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
                     "requires": {
-                        "restore-cursor": "^3.1.0"
+                        "tslib": "^2.1.0"
                     }
                 },
-                "escape-string-regexp": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
-                },
-                "figures": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-                    "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-                    "requires": {
-                        "escape-string-regexp": "^1.0.5"
-                    }
-                },
-                "mimic-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-                },
-                "onetime": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-                    "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-                    "requires": {
-                        "mimic-fn": "^2.1.0"
-                    }
-                },
-                "restore-cursor": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-                    "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-                    "requires": {
-                        "onetime": "^5.1.0",
-                        "signal-exit": "^3.0.2"
-                    }
+                "tslib": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 },
                 "type-fest": {
                     "version": "0.21.3",
@@ -14484,6 +15371,94 @@
                 "inquirer-autosubmit-prompt": "^0.2.0",
                 "rxjs": "^6.5.3",
                 "through": "^2.3.8"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+                    "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "requires": {
+                        "type-fest": "^0.21.3"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+                    "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+                    "requires": {
+                        "restore-cursor": "^3.1.0"
+                    }
+                },
+                "cli-width": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+                    "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+                },
+                "figures": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+                    "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                },
+                "inquirer": {
+                    "version": "7.3.3",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+                    "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+                    "requires": {
+                        "ansi-escapes": "^4.2.1",
+                        "chalk": "^4.1.0",
+                        "cli-cursor": "^3.1.0",
+                        "cli-width": "^3.0.0",
+                        "external-editor": "^3.0.3",
+                        "figures": "^3.0.0",
+                        "lodash": "^4.17.19",
+                        "mute-stream": "0.0.8",
+                        "run-async": "^2.4.0",
+                        "rxjs": "^6.6.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0",
+                        "through": "^2.3.6"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+                },
+                "mute-stream": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+                    "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+                },
+                "onetime": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+                    "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+                    "requires": {
+                        "mimic-fn": "^2.1.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+                    "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+                    "requires": {
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.21.3",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                }
             }
         },
         "listr-silent-renderer": {
@@ -14842,9 +15817,9 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mute-stream": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+            "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -14961,11 +15936,6 @@
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
                     "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
-                },
-                "cli-width": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-                    "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
                 },
                 "cosmiconfig": {
                     "version": "8.3.6",
@@ -15160,9 +16130,9 @@
             }
         },
         "optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "requires": {
                 "deep-is": "^0.1.3",
@@ -15170,7 +16140,7 @@
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
                 "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "word-wrap": "^1.2.5"
             }
         },
         "ora": {
@@ -15488,9 +16458,9 @@
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true
         },
         "pupa": {
@@ -16007,6 +16977,20 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
         },
+        "tinycolor2": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+        },
+        "tinygradient": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
+            "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+            "requires": {
+                "@types/tinycolor2": "^1.4.0",
+                "tinycolor2": "^1.0.0"
+            }
+        },
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -16259,12 +17243,6 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
-        "v8-compile-cache": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-            "dev": true
-        },
         "v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -16393,9 +17371,9 @@
             }
         },
         "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true
         },
         "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bloxroute/solana-trader-client-ts",
-    "version": "2.2.4",
+    "version": "2.2.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bloxroute/solana-trader-client-ts",
-            "version": "2.2.4",
+            "version": "2.2.6",
             "license": "MIT",
             "dependencies": {
                 "@grpc/grpc-js": "^1.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,7 @@
                 "axios": "1.1.2",
                 "bs58": "^5.0.0",
                 "dotenv": "^16.0.1",
-                "figlet": "^1.8.1",
                 "google-protobuf": "^3.20.1",
-                "gradient-string": "^3.0.0",
-                "inquirer": "^12.5.2",
                 "isomorphic-ws": "5.0.0",
                 "np": "^10.0.6",
                 "pbkit": "^0.0.53",
@@ -40,7 +37,10 @@
                 "eslint": "^8.21.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-prettier": "^4.2.1",
+                "figlet": "^1.8.1",
+                "gradient-string": "^3.0.0",
                 "husky": "^8.0.1",
+                "inquirer": "^12.5.2",
                 "jest": "^29.7.0",
                 "prettier": "^2.7.1",
                 "ts-jest": "^29.3.2",
@@ -1117,6 +1117,7 @@
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
             "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/figures": "^1.0.11",
@@ -1140,6 +1141,7 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
             "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -1154,6 +1156,7 @@
             "version": "0.21.3",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1165,6 +1168,7 @@
             "version": "5.1.9",
             "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
             "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6"
@@ -1185,6 +1189,7 @@
             "version": "10.1.10",
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
             "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/figures": "^1.0.11",
                 "@inquirer/type": "^3.0.6",
@@ -1211,6 +1216,7 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
             "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -1225,6 +1231,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
             "engines": {
                 "node": ">=14"
             },
@@ -1236,6 +1243,7 @@
             "version": "0.21.3",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1247,6 +1255,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
             "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -1260,6 +1269,7 @@
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
             "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6",
@@ -1281,6 +1291,7 @@
             "version": "4.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
             "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6",
@@ -1310,6 +1321,7 @@
             "version": "4.1.9",
             "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
             "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6"
@@ -1330,6 +1342,7 @@
             "version": "3.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.12.tgz",
             "integrity": "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6"
@@ -1350,6 +1363,7 @@
             "version": "4.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
             "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6",
@@ -1371,6 +1385,7 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
             "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -1385,6 +1400,7 @@
             "version": "0.21.3",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1396,6 +1412,7 @@
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.1.tgz",
             "integrity": "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.1.5",
                 "@inquirer/confirm": "^5.1.9",
@@ -1424,6 +1441,7 @@
             "version": "4.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.12.tgz",
             "integrity": "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6",
@@ -1445,6 +1463,7 @@
             "version": "3.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
             "integrity": "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/figures": "^1.0.11",
@@ -1467,6 +1486,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.1.tgz",
             "integrity": "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/figures": "^1.0.11",
@@ -1490,6 +1510,7 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
             "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -1504,6 +1525,7 @@
             "version": "0.21.3",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1515,6 +1537,7 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
             "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+            "dev": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2655,7 +2678,8 @@
         "node_modules/@types/tinycolor2": {
             "version": "1.4.6",
             "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
-            "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw=="
+            "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
+            "dev": true
         },
         "node_modules/@types/ws": {
             "version": "8.5.3",
@@ -4961,6 +4985,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.1.tgz",
             "integrity": "sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==",
+            "dev": true,
             "bin": {
                 "figlet": "bin/index.js"
             },
@@ -5345,6 +5370,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-3.0.0.tgz",
             "integrity": "sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==",
+            "dev": true,
             "dependencies": {
                 "chalk": "^5.3.0",
                 "tinygradient": "^1.1.5"
@@ -5357,6 +5383,7 @@
             "version": "5.4.1",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
             "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+            "dev": true,
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -5698,6 +5725,7 @@
             "version": "12.5.2",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.5.2.tgz",
             "integrity": "sha512-qoDk/vdSTIaXNXAoNnlg7ubexpJfUo7t8GT2vylxvE49BrLhToFuPPdMViidG2boHV7+AcP1TCkJs/+PPoF2QQ==",
+            "dev": true,
             "dependencies": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/prompts": "^7.4.1",
@@ -5888,6 +5916,7 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
             "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -5902,6 +5931,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
             "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -5910,6 +5940,7 @@
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -5917,12 +5948,14 @@
         "node_modules/inquirer/node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true
         },
         "node_modules/inquirer/node_modules/type-fest": {
             "version": "0.21.3",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -7878,6 +7911,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
             "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+            "dev": true,
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
             }
@@ -9621,12 +9655,14 @@
         "node_modules/tinycolor2": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+            "dev": true
         },
         "node_modules/tinygradient": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
             "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+            "dev": true,
             "dependencies": {
                 "@types/tinycolor2": "^1.4.0",
                 "tinycolor2": "^1.0.0"
@@ -11035,6 +11071,7 @@
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
             "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/figures": "^1.0.11",
@@ -11047,6 +11084,7 @@
                     "version": "4.3.2",
                     "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
                     "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "dev": true,
                     "requires": {
                         "type-fest": "^0.21.3"
                     }
@@ -11054,7 +11092,8 @@
                 "type-fest": {
                     "version": "0.21.3",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+                    "dev": true
                 }
             }
         },
@@ -11062,6 +11101,7 @@
             "version": "5.1.9",
             "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
             "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6"
@@ -11071,6 +11111,7 @@
             "version": "10.1.10",
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
             "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+            "dev": true,
             "requires": {
                 "@inquirer/figures": "^1.0.11",
                 "@inquirer/type": "^3.0.6",
@@ -11086,6 +11127,7 @@
                     "version": "4.3.2",
                     "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
                     "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "dev": true,
                     "requires": {
                         "type-fest": "^0.21.3"
                     }
@@ -11093,17 +11135,20 @@
                 "signal-exit": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-                    "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+                    "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+                    "dev": true
                 },
                 "type-fest": {
                     "version": "0.21.3",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+                    "dev": true
                 },
                 "wrap-ansi": {
                     "version": "6.2.0",
                     "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
                     "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^4.0.0",
                         "string-width": "^4.1.0",
@@ -11116,6 +11161,7 @@
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
             "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6",
@@ -11126,6 +11172,7 @@
             "version": "4.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
             "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6",
@@ -11141,6 +11188,7 @@
             "version": "4.1.9",
             "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
             "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6"
@@ -11150,6 +11198,7 @@
             "version": "3.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.12.tgz",
             "integrity": "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6"
@@ -11159,6 +11208,7 @@
             "version": "4.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
             "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6",
@@ -11169,6 +11219,7 @@
                     "version": "4.3.2",
                     "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
                     "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "dev": true,
                     "requires": {
                         "type-fest": "^0.21.3"
                     }
@@ -11176,7 +11227,8 @@
                 "type-fest": {
                     "version": "0.21.3",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+                    "dev": true
                 }
             }
         },
@@ -11184,6 +11236,7 @@
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.1.tgz",
             "integrity": "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==",
+            "dev": true,
             "requires": {
                 "@inquirer/checkbox": "^4.1.5",
                 "@inquirer/confirm": "^5.1.9",
@@ -11201,6 +11254,7 @@
             "version": "4.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.12.tgz",
             "integrity": "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/type": "^3.0.6",
@@ -11211,6 +11265,7 @@
             "version": "3.0.12",
             "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
             "integrity": "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/figures": "^1.0.11",
@@ -11222,6 +11277,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.1.tgz",
             "integrity": "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/figures": "^1.0.11",
@@ -11234,6 +11290,7 @@
                     "version": "4.3.2",
                     "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
                     "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "dev": true,
                     "requires": {
                         "type-fest": "^0.21.3"
                     }
@@ -11241,7 +11298,8 @@
                 "type-fest": {
                     "version": "0.21.3",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+                    "dev": true
                 }
             }
         },
@@ -11249,6 +11307,7 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
             "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+            "dev": true,
             "requires": {}
         },
         "@istanbuljs/load-nyc-config": {
@@ -12174,7 +12233,8 @@
         "@types/tinycolor2": {
             "version": "1.4.6",
             "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
-            "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw=="
+            "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
+            "dev": true
         },
         "@types/ws": {
             "version": "8.5.3",
@@ -13751,7 +13811,8 @@
         "figlet": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.1.tgz",
-            "integrity": "sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg=="
+            "integrity": "sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==",
+            "dev": true
         },
         "figures": {
             "version": "2.0.0",
@@ -14018,6 +14079,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-3.0.0.tgz",
             "integrity": "sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==",
+            "dev": true,
             "requires": {
                 "chalk": "^5.3.0",
                 "tinygradient": "^1.1.5"
@@ -14026,7 +14088,8 @@
                 "chalk": {
                     "version": "5.4.1",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-                    "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="
+                    "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+                    "dev": true
                 }
             }
         },
@@ -14260,6 +14323,7 @@
             "version": "12.5.2",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.5.2.tgz",
             "integrity": "sha512-qoDk/vdSTIaXNXAoNnlg7ubexpJfUo7t8GT2vylxvE49BrLhToFuPPdMViidG2boHV7+AcP1TCkJs/+PPoF2QQ==",
+            "dev": true,
             "requires": {
                 "@inquirer/core": "^10.1.10",
                 "@inquirer/prompts": "^7.4.1",
@@ -14274,6 +14338,7 @@
                     "version": "4.3.2",
                     "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
                     "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+                    "dev": true,
                     "requires": {
                         "type-fest": "^0.21.3"
                     }
@@ -14281,12 +14346,14 @@
                 "run-async": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-                    "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q=="
+                    "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+                    "dev": true
                 },
                 "rxjs": {
                     "version": "7.8.2",
                     "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
                     "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+                    "dev": true,
                     "requires": {
                         "tslib": "^2.1.0"
                     }
@@ -14294,12 +14361,14 @@
                 "tslib": {
                     "version": "2.8.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+                    "dev": true
                 },
                 "type-fest": {
                     "version": "0.21.3",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+                    "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+                    "dev": true
                 }
             }
         },
@@ -15819,7 +15888,8 @@
         "mute-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-            "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="
+            "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+            "dev": true
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -16980,12 +17050,14 @@
         "tinycolor2": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+            "dev": true
         },
         "tinygradient": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
             "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+            "dev": true,
             "requires": {
                 "@types/tinycolor2": "^1.4.0",
                 "tinycolor2": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "./examples/"
     ],
     "scripts": {
-        "start": "node --experimental-specifier-resolution=node --loader ts-node/esm ./examples/index.ts",
+        "start": "npx tsx sdk.ts",
         "test:ci": "echo \"Circle CI not yet configured to run tests.\"",
         "test": "jest",
         "build": "npm run esbuild && npm run types",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,10 @@
         "axios": "1.1.2",
         "bs58": "^5.0.0",
         "dotenv": "^16.0.1",
+        "figlet": "^1.8.1",
         "google-protobuf": "^3.20.1",
+        "gradient-string": "^3.0.0",
+        "inquirer": "^12.5.2",
         "isomorphic-ws": "5.0.0",
         "np": "^10.0.6",
         "pbkit": "^0.0.53",
@@ -85,6 +88,7 @@
         "jest": "^29.7.0",
         "prettier": "^2.7.1",
         "ts-jest": "^29.3.2",
-        "ts-proto": "^1.115.5"
+        "ts-proto": "^1.115.5",
+        "@bloxroute/solana-trader-client-ts": "2.2.7"
     }
 }

--- a/package.json
+++ b/package.json
@@ -60,10 +60,7 @@
         "axios": "1.1.2",
         "bs58": "^5.0.0",
         "dotenv": "^16.0.1",
-        "figlet": "^1.8.1",
         "google-protobuf": "^3.20.1",
-        "gradient-string": "^3.0.0",
-        "inquirer": "^12.5.2",
         "isomorphic-ws": "5.0.0",
         "np": "^10.0.6",
         "pbkit": "^0.0.53",
@@ -73,6 +70,7 @@
         "ws": "^8.8.0"
     },
     "devDependencies": {
+        "@bloxroute/solana-trader-client-ts": "2.2.7",
         "@protobuf-ts/plugin": "^2.7.0",
         "@types/google-protobuf": "^3.15.6",
         "@types/jest": "^29.5.14",
@@ -84,11 +82,13 @@
         "eslint": "^8.21.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "figlet": "^1.8.1",
+        "gradient-string": "^3.0.0",
         "husky": "^8.0.1",
+        "inquirer": "^12.5.2",
         "jest": "^29.7.0",
         "prettier": "^2.7.1",
         "ts-jest": "^29.3.2",
-        "ts-proto": "^1.115.5",
-        "@bloxroute/solana-trader-client-ts": "2.2.7"
+        "ts-proto": "^1.115.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bloxroute/solana-trader-client-ts",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "description": "Solana Trader API SDK",
     "type": "module",
     "exports": {

--- a/sdk.ts
+++ b/sdk.ts
@@ -10,10 +10,9 @@ import figlet from 'figlet';
 import chalk from 'chalk';
 import {
   // General
-  MAINNET_API_GRPC_PORT,
-  MAINNET_API_NY_GRPC,
-  MAINNET_API_PUMP_NY_GRPC
   GrpcProvider,
+  HttpProvider,
+  WsProvider,
   loadFromEnv,
   Config,
   // Request types
@@ -25,7 +24,6 @@ import {
   GetPriorityFeeRequest,
   GetBundleTipRequest,
   GetTokenAccountsRequest,
-  GetLeaderScheduleRequest,
   // Response types
   GetRecentBlockHashResponse,
   GetPriorityFeeResponse,
@@ -36,20 +34,27 @@ import {
   GetPumpFunSwapsStreamResponse,
   GetNewRaydiumPoolsResponse
 } from "@bloxroute/solana-trader-client-ts";
+import bs58 from 'bs58'
+import {
+    PublicKey,
+    Keypair,
+    SystemProgram,
+    Transaction,
+    ComputeBudgetProgram,
+  } from '@solana/web3.js';
 
 // Types
 interface SdkFunctionBase {
 }
 
 interface StreamingFunction extends SdkFunctionBase {
-  (protocol?: string, network?: string, times?: number): Promise<SdkFunctionResult>;
+  (protocol: string, network: string, times?: number): Promise<SdkFunctionResult>;
 }
 
 interface RequestFunction extends SdkFunctionBase {
-  (protocol?: string, network?: string): Promise<SdkFunctionResult>;
+  (protocol: string, network: string): Promise<SdkFunctionResult>;
 }
 
-// Then you can use a union type
 type SdkFunction = StreamingFunction | RequestFunction;
 
 interface SdkFunctionResult {
@@ -67,23 +72,54 @@ interface UserAction {
 class AppConfig {
   private static instance: AppConfig;
   public config: Config;
-  public provider: GrpcProvider;
-  public providerPump: GrpcProvider;
+  public grpcProvider: GrpcProvider;
+  public grpcProviderPump: GrpcProvider;
+  public httpProvider: HttpProvider;
+  public httpProviderPump: HttpProvider;
+  public wsProvider: WsProvider;
+  public wsProviderPump: WsProvider;
+  public signer: InstanceType<typeof Keypair>; 
+
 
   private constructor() {
     this.config = loadFromEnv();
-    this.provider = new GrpcProvider(
+    this.grpcProvider = new GrpcProvider(
       this.config.authHeader,
       this.config.privateKey,
-      `${MAINNET_API_NY_GRPC}:${MAINNET_API_GRPC_PORT}`,
+      "ny.solana.dex.blxrbdn.com:443",
       true
     );
-    this.providerPump = new GrpcProvider(
+    this.grpcProviderPump = new GrpcProvider(
       this.config.authHeader,
       this.config.privateKey,
-      `${MAINNET_API_PUMP_NY_GRPC}:${MAINNET_API_GRPC_PORT}`,
+      "pump-ny.solana.dex.blxrbdn.com:443",
       true
     );
+    this.httpProvider = new HttpProvider(
+      this.config.authHeader,
+      this.config.privateKey,
+      "https://ny.solana.dex.blxrbdn.com:443",
+    );
+    this.httpProviderPump = new HttpProvider(
+      this.config.authHeader,
+      this.config.privateKey,
+      "https://pump-ny.solana.dex.blxrbdn.com:443",
+    );
+    this.wsProvider = new WsProvider(
+      this.config.authHeader,
+      this.config.privateKey,
+      "wss://ny.solana.dex.blxrbdn.com/ws",
+    );
+    this.wsProviderPump = new WsProvider(
+      this.config.authHeader,
+      this.config.privateKey,
+      "wss://pump-ny.solana.dex.blxrbdn.com/ws",
+    );
+    this.wsProvider.connect()
+    this.wsProviderPump.connect()
+    this.signer = Keypair.fromSecretKey(
+      bs58.decode(this.config.privateKey)
+    )
   }
 
   public static getInstance(): AppConfig {
@@ -94,20 +130,364 @@ class AppConfig {
   }
 }
 
+// SDK Supported Functions
 class SdkFunctions {
   private static appConfig = AppConfig.getInstance();
 
+  public static getProvider(connectionType: string, isPump: boolean = false): any {
+    switch (connectionType.toLowerCase()) {
+      case 'grpc':
+        return isPump ? SdkFunctions.appConfig.grpcProviderPump : SdkFunctions.appConfig.grpcProvider;
+      case 'http':
+        return isPump ? SdkFunctions.appConfig.httpProviderPump : SdkFunctions.appConfig.httpProvider;
+        case 'websocket':
+          const wsProvider = isPump ? SdkFunctions.appConfig.wsProviderPump : SdkFunctions.appConfig.wsProvider;
+          wsProvider.connect();          
+          return wsProvider;
+      default:
+        throw new Error(`Unsupported connection type: ${connectionType}`);
+    }
+  }
+
   // ======== Transaction Functions =========
+
+  /**
+ * Submit a transaction using postSubmit
+ */
+public static async postSubmit(protocol: string, network: string): Promise<SdkFunctionResult> {
+  try {
+    const signer = SdkFunctions.appConfig.signer;
+    const bloxrouteTipWallet = new PublicKey("HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY");
+    
+    // Create signed transaction
+    const provider = SdkFunctions.getProvider(protocol);
+    const blockhashResponse = await provider.getRecentBlockHash({});
+    
+    // Create transaction with BloXroute tip
+    const transaction = new Transaction({
+      recentBlockhash: blockhashResponse.blockHash,
+      feePayer: signer.publicKey
+    });
+    
+    // Add BloXroute tip
+    transaction.add(
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: bloxrouteTipWallet,
+        lamports: 1_000_000
+      })
+    );
+    
+    // Add compute budget instructions and self-transfer
+    transaction.add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 500_000 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1_000 }),
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: signer.publicKey,
+        lamports: 1
+      })
+    );
+    
+    // Sign the transaction
+    transaction.sign(signer);
+    
+    // Create request
+    const request = {
+      transaction: {
+        content: transaction.serialize().toString(`base64`),
+        isCleanup: false
+      },
+      skipPreFlight: true
+    };
+    
+    // Submit transaction
+    const response = await provider.postSubmit(request);
+    console.info(JSON.stringify(response, null, 2));
+    
+    return {
+      success: true,
+      data: response
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error : new Error(String(error))
+    };
+  }
+}
+
+/**
+ * Submit a transaction using postSubmitV2
+ */
+public static async postSubmitV2(protocol: string, network: string): Promise<SdkFunctionResult> {
+  try {
+    const signer = SdkFunctions.appConfig.signer;
+    const bloxrouteTipWallet = new PublicKey("HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY");
+    
+    // Create signed transaction
+    const provider = SdkFunctions.getProvider(protocol);
+    const blockhashResponse = await provider.getRecentBlockHash({});
+    
+    // Create transaction with BloXroute tip
+    const transaction = new Transaction({
+      recentBlockhash: blockhashResponse.blockHash,
+      feePayer: signer.publicKey
+    });
+    
+    // Add BloXroute tip
+    transaction.add(
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: bloxrouteTipWallet,
+        lamports: 1_000_000
+      })
+    );
+    
+    // Add compute budget instructions and self-transfer
+    transaction.add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 500_000 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1_000 }),
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: signer.publicKey,
+        lamports: 1
+      })
+    );
+    
+    // Sign the transaction
+    transaction.sign(signer);
+    
+    // Create request
+    const request = {
+      transaction: {
+        content: transaction.serialize().toString(`base64`),
+        isCleanup: false
+      },
+      skipPreFlight: true
+    };
+    
+    // Submit transaction using V2
+    const response = await provider.postSubmitV2(request);
+    console.info(JSON.stringify(response, null, 2));
+    
+    return {
+      success: true,
+      data: response
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error : new Error(String(error))
+    };
+  }
+}
+
+/**
+ * Submit a transaction using postSubmitPaladinV2
+ */
+public static async postSubmitPaladinV2(protocol: string, network: string): Promise<SdkFunctionResult> {
+  try {
+    const signer = SdkFunctions.appConfig.signer;
+    const bloxrouteTipWallet = new PublicKey("HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY");
+    
+    // Create signed transaction
+    const provider = SdkFunctions.getProvider(protocol);
+    const blockhashResponse = await provider.getRecentBlockHash({});
+    
+    // Create transaction with BloXroute tip
+    const transaction = new Transaction({
+      recentBlockhash: blockhashResponse.blockHash,
+      feePayer: signer.publicKey
+    });
+    
+    // Add BloXroute tip
+    transaction.add(
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: bloxrouteTipWallet,
+        lamports: 10_000_000
+      })
+    );
+    
+    // Add compute budget instructions and self-transfer
+    transaction.add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 1_000_000 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 40_000_000 }),
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: signer.publicKey,
+        lamports: 1
+      })
+    );
+    
+    // Sign the transaction
+    transaction.sign(signer);
+    
+    // Create request
+    const request = {
+      transaction: {
+        content: transaction.serialize().toString(`base64`),
+      },
+      revertProtection: true
+    };
+    
+    // Submit transaction using paladin V2
+    const response = await provider.postSubmitPaladinV2(request);
+    console.info(JSON.stringify(response, null, 2));
+    
+    return {
+      success: true,
+      data: response
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error : new Error(String(error))
+    };
+  }
+}
+
+/**
+ * Submit snipe transactions using postSubmitSnipeV2
+ */
+public static async postSubmitSnipeV2(protocol: string, network: string): Promise<SdkFunctionResult> {
+  try {
+    const signer = SdkFunctions.appConfig.signer;
+    const bloxrouteTipWallet = new PublicKey("HWEoBxYs7ssKuudEjzjmpfJVX7Dvi7wescFsVx2L5yoY");
+    const jitoTipWallet = new PublicKey("96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5");
+    
+    // Create signed transactions
+    const provider = SdkFunctions.getProvider(protocol);
+    const blockhashResponse = await provider.getRecentBlockHash({});
+    const blockHash = blockhashResponse.blockHash;
+    
+    // First transaction: transfer to both jito and bloxroute
+    const transaction1 = new Transaction({
+      recentBlockhash: blockHash,
+      feePayer: signer.publicKey
+    });
+    
+    transaction1.add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 500_000 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1_000 }),
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: jitoTipWallet,
+        lamports: 100_000
+      }),
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: bloxrouteTipWallet,
+        lamports: 1_000_000
+      })
+    );
+    
+    transaction1.sign(signer);
+    
+    // Second transaction with BloXroute tip
+    const transaction2 = new Transaction({
+      recentBlockhash: blockHash,
+      feePayer: signer.publicKey
+    });
+    
+    transaction2.add(
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: bloxrouteTipWallet,
+        lamports: 1_000_000
+      })
+    );
+    
+    transaction2.add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 500_000 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1_000 }),
+      SystemProgram.transfer({
+        fromPubkey: signer.publicKey,
+        toPubkey: signer.publicKey,
+        lamports: 1
+      })
+    );
+    
+    transaction2.sign(signer);
+    
+    // Create snipe request
+    const request = {
+      entries: [transaction1, transaction2].map(tx => ({
+        transaction: {
+          content: tx.serialize().toString('base64'),
+          isCleanup: false
+        }
+      })),
+      useStakedRPCs: true
+    };
+    
+    // Submit snipe request
+    const response = await provider.postSubmitSnipeV2(request);
+    console.info(JSON.stringify(response, null, 2));
+    
+    return {
+      success: true,
+      data: response
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error : new Error(String(error))
+    };
+  }
+}
+
+/**
+ * Post a SOL Swap for PumpFun
+ */
+public static async postPumpFunSwapSol(protocol: string, network: string): Promise<SdkFunctionResult> {
+  try {
+    const provider = SdkFunctions.getProvider(protocol, true); // Use pump provider
+    
+    // Get new PumpFun token
+    const newTokens = await SdkFunctions.getPumpFunNewTokensStream(protocol, network, 1);
+    const token = newTokens.data[0]
+    console.info(JSON.stringify(token, null, 2));
+    
+    // Create swap request
+    const request = {
+      userAddress: token.creator,
+      bondingCurveAddress: token.bondingCurve,
+      tokenAddress: token.mint,
+      solAmount: 0.0001,
+      slippage: 20,
+      computeLimit: 250_000,
+      computePrice: "100000",
+      tip: "1000000"
+    };
+    
+    // Post swap for transaction
+    const response = await provider.postPumpFunSwapSol(request);
+    console.info(JSON.stringify(response, null, 2));
+    
+    return {
+      success: true,
+      data: response
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error : new Error(String(error))
+    };
+  }
+}
 
   // ======== Streaming Functions =========
 
   /**
    * Get recent block hash stream
    */
-  public static async getRecentBlockHashStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+  public static async getRecentBlockHashStream(protocol: string, network: string, times: number = 5): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetRecentBlockHashRequest;
-          const stream = await SdkFunctions.appConfig.provider.getRecentBlockHashStream(request);
+          const provider = SdkFunctions.getProvider(protocol);
+          const stream = await provider.getRecentBlockHashStream(request);
           
           const responses: GetRecentBlockHashResponse[] = [];
           for await (const response of stream) {
@@ -134,10 +514,11 @@ class SdkFunctions {
   /**
    * Get priority fee stream
    */
-  public static async getPriorityFeeStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+  public static async getPriorityFeeStream(protocol: string, network: string, times: number = 5): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetPriorityFeeRequest;
-          const stream = await SdkFunctions.appConfig.provider.getPriorityFeeStream(request);
+          const provider = SdkFunctions.getProvider(protocol);
+          const stream = await provider.getPriorityFeeStream(request);
           
           const responses: GetPriorityFeeResponse[] = [];
           for await (const response of stream) {
@@ -164,10 +545,11 @@ class SdkFunctions {
   /**
    * Get bundle tip stream
    */
-  public static async getBundleTipStream(protocol?: string, network?: string, times: number = 1): Promise<SdkFunctionResult> {
+  public static async getBundleTipStream(protocol: string, network: string, times: number = 1): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetBundleTipRequest;
-          const stream = await SdkFunctions.appConfig.provider.getBundleTipStream(request);
+          const provider = SdkFunctions.getProvider(protocol);
+          const stream = await provider.getBundleTipStream(request);
           
           const responses: GetBundleTipResponse[] = []
           for await (const response of stream) {
@@ -194,10 +576,11 @@ class SdkFunctions {
   /**
    * Get new PumpSwap AMM pool stream
    */
-  public static async getPumpFunNewAmmPoolStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+  public static async getPumpFunNewAmmPoolStream(protocol: string, network: string, times: number = 5): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetPumpFunNewAmmPoolStreamRequest;
-          const stream = await SdkFunctions.appConfig.providerPump.getPumpFunNewAmmPoolStream(request);
+          const provider = SdkFunctions.getProvider(protocol, true);
+          const stream = await provider.getPumpFunNewAmmPoolStream(request);
           
           const responses: GetPumpFunNewAmmPoolStreamResponse[] = [];
           for await (const response of stream) {
@@ -224,10 +607,11 @@ class SdkFunctions {
   /**
    * Get new PumpFun tokens stream
    */
-  public static async getPumpFunNewTokensStream(protocol?: string, network?: string, times: number = 1): Promise<SdkFunctionResult> {
+  public static async getPumpFunNewTokensStream(protocol: string, network: string, times: number = 1): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetPumpFunNewTokensStreamRequest;
-          const stream = await SdkFunctions.appConfig.providerPump.getPumpFunNewTokensStream(request);
+          const provider = SdkFunctions.getProvider(protocol, true);
+          const stream = await provider.getPumpFunNewTokensStream(request);
           
           const responses: GetPumpFunNewTokensStreamResponse[] = [];
           for await (const response of stream) {
@@ -254,16 +638,18 @@ class SdkFunctions {
   /**
    * Get new Pump Fun swaps stream
    */
-  public static async getPumpFunSwapsStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+  public static async getPumpFunSwapsStream(protocol: string, network: string, times: number = 1): Promise<SdkFunctionResult> {
       try {          
           // Get a new token to monitor
-          const newTokens = await this.getPumpFunNewTokensStream(undefined, undefined, 1);
+          const newTokens = await SdkFunctions.getPumpFunNewTokensStream(protocol, network, 1);
 
           const request = {
-              tokens: [newTokens[0].mint]
+              tokens: [newTokens.data[0].mint]
           } as GetPumpFunSwapsStreamRequest;
+
+          const provider = SdkFunctions.getProvider(protocol, true);
           
-          const stream = await SdkFunctions.appConfig.providerPump.getPumpFunSwapsStream(request);
+          const stream = await provider.getPumpFunSwapsStream(request);
           
           const responses: GetPumpFunSwapsStreamResponse[] = [];
           for await (const response of stream) {
@@ -290,10 +676,11 @@ class SdkFunctions {
   /**
    * Get new Raydium pools stream
    */
-  public static async getNewRaydiumPoolsStream(protocol?: string, network?: string, times: number = 1): Promise<SdkFunctionResult> {
+  public static async getNewRaydiumPoolsStream(protocol: string, network: string, times: number = 1): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetPumpFunNewAmmPoolStreamRequest;
-          const stream = await SdkFunctions.appConfig.provider.getNewRaydiumPoolsStream(request);
+          const provider = SdkFunctions.getProvider(protocol);
+          const stream = await provider.getNewRaydiumPoolsStream(request);
           
           const responses: GetNewRaydiumPoolsResponse[] = [];
           for await (const response of stream) {
@@ -320,10 +707,11 @@ class SdkFunctions {
   /**
    * Get new Raydium pools by transaction stream
    */
-  public static async getNewRaydiumPoolsByTransactionStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+  public static async getNewRaydiumPoolsByTransactionStream(protocol: string, network: string, times: number = 5): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetNewRaydiumPoolsByTransactionRequest;
-          const stream = await SdkFunctions.appConfig.provider.getNewRaydiumPoolsByTransactionStream(request);
+          const provider = SdkFunctions.getProvider(protocol);
+          const stream = await provider.getNewRaydiumPoolsByTransactionStream(request);
           
           const responses: GetNewRaydiumPoolsByTransactionResponse[] = [];
           for await (const response of stream) {
@@ -352,14 +740,14 @@ class SdkFunctions {
   /**
    * Get token accounts
    */
-  public static async getTokenAccounts(): Promise<SdkFunctionResult> {
+  public static async getTokenAccounts(protocol: string, network: string): Promise<SdkFunctionResult> {
       try {
           
           const request = {
               ownerAddress: "AfU4AhJhqSsMji1oij1ZGfskQGGmmUW1vsdS3j7eeEwj"
           } as GetTokenAccountsRequest;
-          
-          const response = await SdkFunctions.appConfig.provider.getTokenAccounts(request);
+          const provider = SdkFunctions.getProvider(protocol);
+          const response = await provider.getTokenAccounts(request);
           console.info(JSON.stringify(response, null, 2));
           
           return { 
@@ -377,7 +765,7 @@ class SdkFunctions {
   /**
    * Get priority fee
    */
-  public static async getPriorityFee(): Promise<SdkFunctionResult> {
+  public static async getPriorityFee(protocol: string, network: string): Promise<SdkFunctionResult> {
       try {
 
           const request = {
@@ -385,7 +773,8 @@ class SdkFunctions {
               percentile: 50
           } as GetPriorityFeeRequest;
           
-          const response = await SdkFunctions.appConfig.provider.getPriorityFee(request);
+          const provider = SdkFunctions.getProvider(protocol);
+          const response = await provider.getPriorityFee(request);
           console.info(JSON.stringify(response, null, 2));
           
           return { 
@@ -401,53 +790,44 @@ class SdkFunctions {
   }
 
   /**
-   * Get leader schedule
+   * Get all available SDK functions based on connection type
+   * @param connectionType - The selected connection type
+   * @returns Record of available functions for the selected connection type
    */
-  public static async getLeaderSchedule(protocol?: string, network?: string): Promise<SdkFunctionResult> {
-      try {
-          
-          const request = {} as GetLeaderScheduleRequest;
-          
-          const response = await SdkFunctions.appConfig.provider.getLeaderSchedule(request);
-          console.info(JSON.stringify(response, null, 2));
-          
-          return { 
-              success: true,
-              data: response 
-          };
-      } catch (error) {
-          return {
-              success: false,
-              error: error instanceof Error ? error : new Error(String(error))
-          };
-      }
-  }
-
-  /**
-   * Get all available SDK functions
-   */
-  public static getAvailableFunctions(): Record<string, SdkFunction> {
-      return {
-          
-          // Streaming functions
-          GetRecentBlockHashStream: SdkFunctions.getRecentBlockHashStream,
-          GetPriorityFeeStream: SdkFunctions.getPriorityFeeStream,
-          GetBundleTipStream: SdkFunctions.getBundleTipStream,
-          GetPumpFunNewAmmPoolStream: SdkFunctions.getPumpFunNewAmmPoolStream,
-          GetPumpFunNewTokensStream: SdkFunctions.getPumpFunNewTokensStream,
-          GetPumpFunSwapsStream: SdkFunctions.getPumpFunSwapsStream,
-          GetNewRaydiumPoolsStream: SdkFunctions.getNewRaydiumPoolsStream,
-          GetNewRaydiumPoolsByTransactionStream: SdkFunctions.getNewRaydiumPoolsByTransactionStream,
-          
-          // Request functions
-          GetTokenAccounts: SdkFunctions.getTokenAccounts,
-          GetPriorityFee: SdkFunctions.getPriorityFee,
-          GetLeaderSchedule: SdkFunctions.getLeaderSchedule
-      };
+  public static getAvailableFunctions(connectionType: string): Record<string, SdkFunction> {
+    // Base non-streaming functions available for all connection types
+    const baseFunctions: Record<string, SdkFunction> = {
+      // Request functions
+      GetTokenAccounts: SdkFunctions.getTokenAccounts,
+      GetPriorityFee: SdkFunctions.getPriorityFee,
+      PostSubmit: SdkFunctions.postSubmit,
+      PostSubmitV2: SdkFunctions.postSubmitV2,
+      PostSubmitSnipeV2: SdkFunctions.postSubmitSnipeV2,
+      PostSubmitPaladinV2: SdkFunctions.postSubmitPaladinV2,
+      PostPumpFunSwapSol: SdkFunctions.postPumpFunSwapSol,
+    };
+    
+    // For HTTP, we only provide non-streaming functions
+    if (connectionType.toLowerCase() === 'http') {
+      return baseFunctions;
+    }
+    
+    // For gRPC and WebSocket, include streaming functions
+    return {
+      ...baseFunctions,
+      // Streaming functions
+      GetRecentBlockHashStream: SdkFunctions.getRecentBlockHashStream,
+      GetPriorityFeeStream: SdkFunctions.getPriorityFeeStream,
+      GetBundleTipStream: SdkFunctions.getBundleTipStream,
+      GetPumpFunNewAmmPoolStream: SdkFunctions.getPumpFunNewAmmPoolStream,
+      GetPumpFunNewTokensStream: SdkFunctions.getPumpFunNewTokensStream,
+      GetPumpFunSwapsStream: SdkFunctions.getPumpFunSwapsStream,
+      GetNewRaydiumPoolsStream: SdkFunctions.getNewRaydiumPoolsStream,
+      GetNewRaydiumPoolsByTransactionStream: SdkFunctions.getNewRaydiumPoolsByTransactionStream,
+    };
   }
 }
 
-// Export the class
 export default SdkFunctions;
 
 // UI Components
@@ -474,22 +854,22 @@ class UserInterface {
     console.log(chalk.dim(' Use your arrow keys to navigate through the menus') + '\n');
   }
 
-  /**
-   * Show protocol selection menu
-   * @returns Selected protocol
-   */
-  public static async selectProtocol(): Promise<string> {
-    const { protocol } = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'protocol',
-        message: 'Select connection protocol:',
-        choices: ['gRPC'],
-      }
-    ]);
-    
-    return protocol;
-  }
+/**
+ * Show connection type selection menu
+ * @returns Selected connection type
+ */
+public static async selectConnectionType(): Promise<string> {
+  const { connectionType } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'connectionType',
+      message: 'Select connection type:',
+      choices: ['gRPC', 'HTTP', 'WebSocket'],
+    }
+  ]);
+  
+  return connectionType;
+}
 
   /**
    * Show network selection menu
@@ -565,27 +945,47 @@ class UserInterface {
   }
 }
 
-// Main application class
+// Track whether cleanup has already been performed
+let cleanupPerformed = false;
+
+function cleanup(): void {
+  // If cleanup has already been performed, do nothing
+  if (cleanupPerformed) {
+    return;
+  }
+  
+  console.log(chalk.yellow('\nCleaning up connections...'));
+  
+  const appConfig = AppConfig.getInstance();
+  appConfig.wsProvider.close();
+  appConfig.wsProviderPump.close();
+  
+  console.log(chalk.green('Connections closed successfully.'));
+  
+  // Mark cleanup as performed
+  cleanupPerformed = true;
+}
+
 class BloxRouteCliApp {
-  private protocol = '';
+  private connectionType = '';
   private network = '';
   private sdkFunctions: Record<string, SdkFunction>;
 
   constructor() {
     // Initialize AppConfig singleton to set up providers
     AppConfig.getInstance();
-    this.sdkFunctions = SdkFunctions.getAvailableFunctions();
+    this.sdkFunctions = {};
   }
 
   /**
-   * Execute the selected function with the given protocol and network
+   * Execute the selected function with the given connection type and network
    * @param functionName - Name of the function to execute
    */
   private async executeFunction(functionName: string): Promise<void> {
     console.log(chalk.yellow('\nExecuting function, please wait...\n'));
     
     try {
-      const result = await this.sdkFunctions[functionName](this.protocol, this.network);
+      const result = await this.sdkFunctions[functionName](this.connectionType, this.network);
       
       if (result.success) {
         console.log(chalk.green('\nSuccess!'));
@@ -601,12 +1001,15 @@ class BloxRouteCliApp {
   }
 
   /**
-   * Configure protocol and network settings
+   * Configure connection type and network settings
    */
   private async configureSettings(): Promise<void> {
-    // Select protocol
-    this.protocol = await UserInterface.selectProtocol();
-    console.log(chalk.green(`Selected protocol: ${this.protocol}`));
+    // Select connection type
+    this.connectionType = await UserInterface.selectConnectionType();
+    console.log(chalk.green(`Selected connection type: ${this.connectionType}`));
+    
+    // Update available functions based on selected connection type
+    this.sdkFunctions = SdkFunctions.getAvailableFunctions(this.connectionType);
     
     // Select network
     this.network = await UserInterface.selectNetwork();
@@ -631,7 +1034,7 @@ class BloxRouteCliApp {
       // Execute the selected function
       await this.executeFunction(selectedFunction);
       
-      // Ask what the user wants to do next - ONLY ONCE
+      // Ask what the user wants to do next
       const action = await UserInterface.getNextAction();
       continueRunning = action.continue;
       
@@ -639,12 +1042,40 @@ class BloxRouteCliApp {
         return this.run(); // Restart from the beginning
       }
     }
+
+    // Call cleanup when user selects exit
+    cleanup();
     
     console.log(chalk.blue('\nThank you for using the BloxRoute SDK CLI!'));
   }
 }
 
+function setupSignalHandlers(): void {
+  process.on('SIGINT', () => {
+    console.log('\nReceived SIGINT. Shutting down gracefully...');
+    cleanup();
+    
+    // Allow some time for cleanup before exiting
+    setTimeout(() => {
+      console.log('Exiting application');
+      process.exit(0);
+    }, 500);
+  });
+  
+  // Handle other termination signals too
+  process.on('SIGTERM', () => {
+    console.log('\nReceived SIGTERM. Shutting down gracefully...');
+    cleanup();
+    
+    setTimeout(() => {
+      console.log('Exiting application');
+      process.exit(0);
+    }, 500);
+  });
+}
+
 // Start the application
+setupSignalHandlers();
 const app = new BloxRouteCliApp();
 app.run().catch((error) => {
   console.error('Application error:', error);

--- a/sdk.ts
+++ b/sdk.ts
@@ -134,7 +134,7 @@ class AppConfig {
 class SdkFunctions {
   private static appConfig = AppConfig.getInstance();
 
-  public static getProvider(connectionType: string, isPump: boolean = false): any {
+  public static getProvider(connectionType: string, isPump = false): any {
     switch (connectionType.toLowerCase()) {
       case 'grpc':
         return isPump ? SdkFunctions.appConfig.grpcProviderPump : SdkFunctions.appConfig.grpcProvider;
@@ -483,7 +483,7 @@ public static async postPumpFunSwapSol(protocol: string, network: string): Promi
   /**
    * Get recent block hash stream
    */
-  public static async getRecentBlockHashStream(protocol: string, network: string, times: number = 5): Promise<SdkFunctionResult> {
+  public static async getRecentBlockHashStream(protocol: string, network: string, times = 5): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetRecentBlockHashRequest;
           const provider = SdkFunctions.getProvider(protocol);
@@ -514,7 +514,7 @@ public static async postPumpFunSwapSol(protocol: string, network: string): Promi
   /**
    * Get priority fee stream
    */
-  public static async getPriorityFeeStream(protocol: string, network: string, times: number = 5): Promise<SdkFunctionResult> {
+  public static async getPriorityFeeStream(protocol: string, network: string, times = 5): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetPriorityFeeRequest;
           const provider = SdkFunctions.getProvider(protocol);
@@ -545,7 +545,7 @@ public static async postPumpFunSwapSol(protocol: string, network: string): Promi
   /**
    * Get bundle tip stream
    */
-  public static async getBundleTipStream(protocol: string, network: string, times: number = 1): Promise<SdkFunctionResult> {
+  public static async getBundleTipStream(protocol: string, network: string, times = 1): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetBundleTipRequest;
           const provider = SdkFunctions.getProvider(protocol);
@@ -576,7 +576,7 @@ public static async postPumpFunSwapSol(protocol: string, network: string): Promi
   /**
    * Get new PumpSwap AMM pool stream
    */
-  public static async getPumpFunNewAmmPoolStream(protocol: string, network: string, times: number = 5): Promise<SdkFunctionResult> {
+  public static async getPumpFunNewAmmPoolStream(protocol: string, network: string, times = 5): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetPumpFunNewAmmPoolStreamRequest;
           const provider = SdkFunctions.getProvider(protocol, true);
@@ -607,7 +607,7 @@ public static async postPumpFunSwapSol(protocol: string, network: string): Promi
   /**
    * Get new PumpFun tokens stream
    */
-  public static async getPumpFunNewTokensStream(protocol: string, network: string, times: number = 1): Promise<SdkFunctionResult> {
+  public static async getPumpFunNewTokensStream(protocol: string, network: string, times = 1): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetPumpFunNewTokensStreamRequest;
           const provider = SdkFunctions.getProvider(protocol, true);
@@ -638,7 +638,7 @@ public static async postPumpFunSwapSol(protocol: string, network: string): Promi
   /**
    * Get new Pump Fun swaps stream
    */
-  public static async getPumpFunSwapsStream(protocol: string, network: string, times: number = 1): Promise<SdkFunctionResult> {
+  public static async getPumpFunSwapsStream(protocol: string, network: string, times = 1): Promise<SdkFunctionResult> {
       try {          
           // Get a new token to monitor
           const newTokens = await SdkFunctions.getPumpFunNewTokensStream(protocol, network, 1);
@@ -676,7 +676,7 @@ public static async postPumpFunSwapSol(protocol: string, network: string): Promi
   /**
    * Get new Raydium pools stream
    */
-  public static async getNewRaydiumPoolsStream(protocol: string, network: string, times: number = 1): Promise<SdkFunctionResult> {
+  public static async getNewRaydiumPoolsStream(protocol: string, network: string, times = 1): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetPumpFunNewAmmPoolStreamRequest;
           const provider = SdkFunctions.getProvider(protocol);
@@ -707,7 +707,7 @@ public static async postPumpFunSwapSol(protocol: string, network: string): Promi
   /**
    * Get new Raydium pools by transaction stream
    */
-  public static async getNewRaydiumPoolsByTransactionStream(protocol: string, network: string, times: number = 5): Promise<SdkFunctionResult> {
+  public static async getNewRaydiumPoolsByTransactionStream(protocol: string, network: string, times = 5): Promise<SdkFunctionResult> {
       try {
           const request = {} as GetNewRaydiumPoolsByTransactionRequest;
           const provider = SdkFunctions.getProvider(protocol);

--- a/sdk.ts
+++ b/sdk.ts
@@ -1,0 +1,652 @@
+/**
+ * BloxRoute SDK CLI for TypeScript - Solana Trader
+ * An interactive CLI tool for exploring BloxRoute SDK functionality
+ */
+
+// Import required libraries
+import inquirer from 'inquirer';
+import gradient from 'gradient-string';
+import figlet from 'figlet';
+import chalk from 'chalk';
+import {
+  // General
+  MAINNET_API_GRPC_PORT,
+  MAINNET_API_NY_GRPC,
+  MAINNET_API_PUMP_NY_GRPC
+  GrpcProvider,
+  loadFromEnv,
+  Config,
+  // Request types
+  GetRecentBlockHashRequest,
+  GetPumpFunNewAmmPoolStreamRequest,
+  GetPumpFunNewTokensStreamRequest,
+  GetPumpFunSwapsStreamRequest,
+  GetNewRaydiumPoolsByTransactionRequest,
+  GetPriorityFeeRequest,
+  GetBundleTipRequest,
+  GetTokenAccountsRequest,
+  GetLeaderScheduleRequest,
+  // Response types
+  GetRecentBlockHashResponse,
+  GetPriorityFeeResponse,
+  GetBundleTipResponse,
+  GetPumpFunNewAmmPoolStreamResponse,
+  GetNewRaydiumPoolsByTransactionResponse,
+  GetPumpFunNewTokensStreamResponse,
+  GetPumpFunSwapsStreamResponse,
+  GetNewRaydiumPoolsResponse
+} from "@bloxroute/solana-trader-client-ts";
+
+// Types
+interface SdkFunctionBase {
+}
+
+interface StreamingFunction extends SdkFunctionBase {
+  (protocol?: string, network?: string, times?: number): Promise<SdkFunctionResult>;
+}
+
+interface RequestFunction extends SdkFunctionBase {
+  (protocol?: string, network?: string): Promise<SdkFunctionResult>;
+}
+
+// Then you can use a union type
+type SdkFunction = StreamingFunction | RequestFunction;
+
+interface SdkFunctionResult {
+  success: boolean;
+  data?: any;
+  error?: Error;
+}
+
+interface UserAction {
+  continue: boolean;
+  restart: boolean;
+}
+
+// Configuration
+class AppConfig {
+  private static instance: AppConfig;
+  public config: Config;
+  public provider: GrpcProvider;
+  public providerPump: GrpcProvider;
+
+  private constructor() {
+    this.config = loadFromEnv();
+    this.provider = new GrpcProvider(
+      this.config.authHeader,
+      this.config.privateKey,
+      `${MAINNET_API_NY_GRPC}:${MAINNET_API_GRPC_PORT}`,
+      true
+    );
+    this.providerPump = new GrpcProvider(
+      this.config.authHeader,
+      this.config.privateKey,
+      `${MAINNET_API_PUMP_NY_GRPC}:${MAINNET_API_GRPC_PORT}`,
+      true
+    );
+  }
+
+  public static getInstance(): AppConfig {
+    if (!AppConfig.instance) {
+      AppConfig.instance = new AppConfig();
+    }
+    return AppConfig.instance;
+  }
+}
+
+class SdkFunctions {
+  private static appConfig = AppConfig.getInstance();
+
+  // ======== Transaction Functions =========
+
+  // ======== Streaming Functions =========
+
+  /**
+   * Get recent block hash stream
+   */
+  public static async getRecentBlockHashStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+      try {
+          const request = {} as GetRecentBlockHashRequest;
+          const stream = await SdkFunctions.appConfig.provider.getRecentBlockHashStream(request);
+          
+          const responses: GetRecentBlockHashResponse[] = [];
+          for await (const response of stream) {
+              console.info(JSON.stringify(response, null, 2));
+              responses.push(response);
+              times--;
+              if (times === 0) {
+                  break;
+              }
+          }
+          
+          return { 
+              success: true,
+              data: responses 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get priority fee stream
+   */
+  public static async getPriorityFeeStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+      try {
+          const request = {} as GetPriorityFeeRequest;
+          const stream = await SdkFunctions.appConfig.provider.getPriorityFeeStream(request);
+          
+          const responses: GetPriorityFeeResponse[] = [];
+          for await (const response of stream) {
+              console.info(JSON.stringify(response, null, 2));
+              responses.push(response);
+              times--;
+              if (times === 0) {
+                  break;
+              }
+          }
+          
+          return { 
+              success: true,
+              data: responses 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get bundle tip stream
+   */
+  public static async getBundleTipStream(protocol?: string, network?: string, times: number = 1): Promise<SdkFunctionResult> {
+      try {
+          const request = {} as GetBundleTipRequest;
+          const stream = await SdkFunctions.appConfig.provider.getBundleTipStream(request);
+          
+          const responses: GetBundleTipResponse[] = []
+          for await (const response of stream) {
+              console.info(JSON.stringify(response, null, 2));
+              responses.push(response);
+              times--;
+              if (times === 0) {
+                  break;
+              }
+          }
+          
+          return { 
+              success: true,
+              data: responses 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get new PumpSwap AMM pool stream
+   */
+  public static async getPumpFunNewAmmPoolStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+      try {
+          const request = {} as GetPumpFunNewAmmPoolStreamRequest;
+          const stream = await SdkFunctions.appConfig.providerPump.getPumpFunNewAmmPoolStream(request);
+          
+          const responses: GetPumpFunNewAmmPoolStreamResponse[] = [];
+          for await (const response of stream) {
+              console.info(JSON.stringify(response, null, 2));
+              responses.push(response);
+              times--;
+              if (times === 0) {
+                  break;
+              }
+          }
+          
+          return { 
+              success: true,
+              data: responses 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get new PumpFun tokens stream
+   */
+  public static async getPumpFunNewTokensStream(protocol?: string, network?: string, times: number = 1): Promise<SdkFunctionResult> {
+      try {
+          const request = {} as GetPumpFunNewTokensStreamRequest;
+          const stream = await SdkFunctions.appConfig.providerPump.getPumpFunNewTokensStream(request);
+          
+          const responses: GetPumpFunNewTokensStreamResponse[] = [];
+          for await (const response of stream) {
+              console.info(JSON.stringify(response, null, 2));
+              responses.push(response);
+              times--;
+              if (times === 0) {
+                  break;
+              }
+          }
+          
+          return { 
+              success: true,
+              data: responses 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get new Pump Fun swaps stream
+   */
+  public static async getPumpFunSwapsStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+      try {          
+          // Get a new token to monitor
+          const newTokens = await this.getPumpFunNewTokensStream(undefined, undefined, 1);
+
+          const request = {
+              tokens: [newTokens[0].mint]
+          } as GetPumpFunSwapsStreamRequest;
+          
+          const stream = await SdkFunctions.appConfig.providerPump.getPumpFunSwapsStream(request);
+          
+          const responses: GetPumpFunSwapsStreamResponse[] = [];
+          for await (const response of stream) {
+              console.info(JSON.stringify(response, null, 2));
+              responses.push(response);
+              times--;
+              if (times === 0) {
+                  break;
+              }
+          }
+          
+          return { 
+              success: true,
+              data: responses 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get new Raydium pools stream
+   */
+  public static async getNewRaydiumPoolsStream(protocol?: string, network?: string, times: number = 1): Promise<SdkFunctionResult> {
+      try {
+          const request = {} as GetPumpFunNewAmmPoolStreamRequest;
+          const stream = await SdkFunctions.appConfig.provider.getNewRaydiumPoolsStream(request);
+          
+          const responses: GetNewRaydiumPoolsResponse[] = [];
+          for await (const response of stream) {
+              console.info(JSON.stringify(response, null, 2));
+              responses.push(response);
+              times--;
+              if (times === 0) {
+                  break;
+              }
+          }
+          
+          return { 
+              success: true,
+              data: responses 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get new Raydium pools by transaction stream
+   */
+  public static async getNewRaydiumPoolsByTransactionStream(protocol?: string, network?: string, times: number = 5): Promise<SdkFunctionResult> {
+      try {
+          const request = {} as GetNewRaydiumPoolsByTransactionRequest;
+          const stream = await SdkFunctions.appConfig.provider.getNewRaydiumPoolsByTransactionStream(request);
+          
+          const responses: GetNewRaydiumPoolsByTransactionResponse[] = [];
+          for await (const response of stream) {
+              console.info(JSON.stringify(response, null, 2));
+              responses.push(response);
+              times--;
+              if (times === 0) {
+                  break;
+              }
+          }
+          
+          return { 
+              success: true,
+              data: responses 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  // ======== Request Functions =========
+
+  /**
+   * Get token accounts
+   */
+  public static async getTokenAccounts(): Promise<SdkFunctionResult> {
+      try {
+          
+          const request = {
+              ownerAddress: "AfU4AhJhqSsMji1oij1ZGfskQGGmmUW1vsdS3j7eeEwj"
+          } as GetTokenAccountsRequest;
+          
+          const response = await SdkFunctions.appConfig.provider.getTokenAccounts(request);
+          console.info(JSON.stringify(response, null, 2));
+          
+          return { 
+              success: true,
+              data: response 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get priority fee
+   */
+  public static async getPriorityFee(): Promise<SdkFunctionResult> {
+      try {
+
+          const request = {
+              project: "P_RAYDIUM",
+              percentile: 50
+          } as GetPriorityFeeRequest;
+          
+          const response = await SdkFunctions.appConfig.provider.getPriorityFee(request);
+          console.info(JSON.stringify(response, null, 2));
+          
+          return { 
+              success: true,
+              data: response 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get leader schedule
+   */
+  public static async getLeaderSchedule(protocol?: string, network?: string): Promise<SdkFunctionResult> {
+      try {
+          
+          const request = {} as GetLeaderScheduleRequest;
+          
+          const response = await SdkFunctions.appConfig.provider.getLeaderSchedule(request);
+          console.info(JSON.stringify(response, null, 2));
+          
+          return { 
+              success: true,
+              data: response 
+          };
+      } catch (error) {
+          return {
+              success: false,
+              error: error instanceof Error ? error : new Error(String(error))
+          };
+      }
+  }
+
+  /**
+   * Get all available SDK functions
+   */
+  public static getAvailableFunctions(): Record<string, SdkFunction> {
+      return {
+          
+          // Streaming functions
+          GetRecentBlockHashStream: SdkFunctions.getRecentBlockHashStream,
+          GetPriorityFeeStream: SdkFunctions.getPriorityFeeStream,
+          GetBundleTipStream: SdkFunctions.getBundleTipStream,
+          GetPumpFunNewAmmPoolStream: SdkFunctions.getPumpFunNewAmmPoolStream,
+          GetPumpFunNewTokensStream: SdkFunctions.getPumpFunNewTokensStream,
+          GetPumpFunSwapsStream: SdkFunctions.getPumpFunSwapsStream,
+          GetNewRaydiumPoolsStream: SdkFunctions.getNewRaydiumPoolsStream,
+          GetNewRaydiumPoolsByTransactionStream: SdkFunctions.getNewRaydiumPoolsByTransactionStream,
+          
+          // Request functions
+          GetTokenAccounts: SdkFunctions.getTokenAccounts,
+          GetPriorityFee: SdkFunctions.getPriorityFee,
+          GetLeaderSchedule: SdkFunctions.getLeaderSchedule
+      };
+  }
+}
+
+// Export the class
+export default SdkFunctions;
+
+// UI Components
+class UserInterface {
+  /**
+   * Display welcome banner with ASCII art
+   */
+  public static async displayBanner(): Promise<void> {
+    console.clear();
+    
+    // Create a colorful gradient text for the banner
+    const bloxGradient = gradient(['#FF5733', '#FFC300', '#36D7B7']);
+
+    // Create ASCII art banner
+    const text = figlet.textSync('BloxRoute SDK', {
+      font: 'Standard',
+      horizontalLayout: 'default',
+      verticalLayout: 'default'
+    });
+
+    console.log(bloxGradient(text));
+    console.log('\n' + chalk.bold(' Welcome to the BloxRoute SDK for TypeScript - Solana Trader') + '\n');
+    console.log(chalk.dim(' Interactive CLI for exploring the BloxRoute SDK functionality'));
+    console.log(chalk.dim(' Use your arrow keys to navigate through the menus') + '\n');
+  }
+
+  /**
+   * Show protocol selection menu
+   * @returns Selected protocol
+   */
+  public static async selectProtocol(): Promise<string> {
+    const { protocol } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'protocol',
+        message: 'Select connection protocol:',
+        choices: ['gRPC'],
+      }
+    ]);
+    
+    return protocol;
+  }
+
+  /**
+   * Show network selection menu
+   * @returns Selected network
+   */
+  public static async selectNetwork(): Promise<string> {
+    const { network } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'network',
+        message: 'Select network:',
+        choices: ['mainnet'],
+      }
+    ]);
+    
+    return network;
+  }
+
+  /**
+   * Show function selection menu
+   * @param availableFunctions - List of available function names
+   * @returns Selected function name
+   */
+  public static async selectFunction(availableFunctions: string[]): Promise<string> {
+    const { selectedFunction } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'selectedFunction',
+        message: 'Select function to execute:',
+        choices: availableFunctions,
+      }
+    ]);
+    
+    return selectedFunction;
+  }
+
+  /**
+   * Ask user for next action
+   * @returns User action choice
+   */
+  public static async getNextAction(): Promise<UserAction> {
+    const { action } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'action',
+        message: 'What would you like to do next?',
+        choices: [
+          { name: 'Execute another function', value: 'continue' },
+          { name: 'Change protocol/network settings', value: 'change' },
+          { name: 'Exit', value: 'exit' }
+        ]
+      }
+    ]);
+    
+    return {
+      continue: action !== 'exit',
+      restart: action === 'change'
+    };
+  }
+
+  /**
+   * Wait for user input to continue
+   */
+  public static async waitForInput(): Promise<void> {
+    console.log('\nPress Enter to continue...');
+    await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'continue',
+        message: '',
+      }
+    ]);
+  }
+}
+
+// Main application class
+class BloxRouteCliApp {
+  private protocol = '';
+  private network = '';
+  private sdkFunctions: Record<string, SdkFunction>;
+
+  constructor() {
+    // Initialize AppConfig singleton to set up providers
+    AppConfig.getInstance();
+    this.sdkFunctions = SdkFunctions.getAvailableFunctions();
+  }
+
+  /**
+   * Execute the selected function with the given protocol and network
+   * @param functionName - Name of the function to execute
+   */
+  private async executeFunction(functionName: string): Promise<void> {
+    console.log(chalk.yellow('\nExecuting function, please wait...\n'));
+    
+    try {
+      const result = await this.sdkFunctions[functionName](this.protocol, this.network);
+      
+      if (result.success) {
+        console.log(chalk.green('\nSuccess!'));
+      } else {
+        throw result.error;
+      }
+    } catch (error) {
+      console.log(chalk.red('\nError executing function:'));
+      console.error(error);
+    }
+    
+    await UserInterface.waitForInput();
+  }
+
+  /**
+   * Configure protocol and network settings
+   */
+  private async configureSettings(): Promise<void> {
+    // Select protocol
+    this.protocol = await UserInterface.selectProtocol();
+    console.log(chalk.green(`Selected protocol: ${this.protocol}`));
+    
+    // Select network
+    this.network = await UserInterface.selectNetwork();
+    console.log(chalk.green(`Selected network: ${this.network}`));
+  }
+
+  /**
+   * Main application flow
+   */
+  public async run(): Promise<void> {
+    await UserInterface.displayBanner();
+    await this.configureSettings();
+    
+    // Function selection and execution loop
+    let continueRunning = true;
+    
+    while (continueRunning) {
+      // Select function to execute
+      const availableFunctions = Object.keys(this.sdkFunctions);
+      const selectedFunction = await UserInterface.selectFunction(availableFunctions);
+      
+      // Execute the selected function
+      await this.executeFunction(selectedFunction);
+      
+      // Ask what the user wants to do next - ONLY ONCE
+      const action = await UserInterface.getNextAction();
+      continueRunning = action.continue;
+      
+      if (action.restart) {
+        return this.run(); // Restart from the beginning
+      }
+    }
+    
+    console.log(chalk.blue('\nThank you for using the BloxRoute SDK CLI!'));
+  }
+}
+
+// Start the application
+const app = new BloxRouteCliApp();
+app.run().catch((error) => {
+  console.error('Application error:', error);
+  process.exit(1);
+});

--- a/sdk.ts
+++ b/sdk.ts
@@ -44,14 +44,11 @@ import {
   } from '@solana/web3.js';
 
 // Types
-interface SdkFunctionBase {
-}
-
-interface StreamingFunction extends SdkFunctionBase {
+interface StreamingFunction {
   (protocol: string, network: string, times?: number): Promise<SdkFunctionResult>;
 }
 
-interface RequestFunction extends SdkFunctionBase {
+interface RequestFunction {
   (protocol: string, network: string): Promise<SdkFunctionResult>;
 }
 
@@ -59,7 +56,7 @@ type SdkFunction = StreamingFunction | RequestFunction;
 
 interface SdkFunctionResult {
   success: boolean;
-  data?: any;
+  data?: any; // eslint-disable-line
   error?: Error;
 }
 
@@ -134,6 +131,7 @@ class AppConfig {
 class SdkFunctions {
   private static appConfig = AppConfig.getInstance();
 
+  // eslint-disable-next-line
   public static getProvider(connectionType: string, isPump = false): any {
     switch (connectionType.toLowerCase()) {
       case 'grpc':

--- a/tests/integration/grpc.test.ts
+++ b/tests/integration/grpc.test.ts
@@ -9,7 +9,19 @@ import {
     TransactionMessageV2,
     PostSubmitPaladinRequest,
     PostSubmitRequestEntry,
-    PostSubmitSnipeRequest
+    PostSubmitSnipeRequest,
+    GetPumpFunNewAmmPoolStreamRequest,
+    GetPumpFunNewTokensStreamRequest,
+    GetPumpFunSwapsStreamRequest,
+    GetNewRaydiumPoolsByTransactionRequest,
+    GetPriorityFeeRequest,
+    GetBundleTipRequest,
+    GetTokenAccountsRequest,
+    GetPumpFunNewTokensStreamResponse,
+    GetPoolReservesStreamRequest,
+    Project,
+    GetLeaderScheduleRequest,
+    PostPumpFunSwapRequestSol
 } from "../../bxsolana";
 import bs58 from 'bs58'
 import {
@@ -19,10 +31,42 @@ import {
     Transaction,
     ComputeBudgetProgram,
   } from '@solana/web3.js';
+import { LOCAL_API_GRPC_HOST, LOCAL_API_GRPC_PORT, MAINNET_API_PUMP_NY_GRPC } from "../../bxsolana/utils/constants";
+
+jest.setTimeout(60500);
+
+function expectNoNulls(response: any) {
+    const { timestamp, ...responseWithoutTimestamp } = response;
+    
+    expect(
+      Object.values(responseWithoutTimestamp).every(v =>
+        v !== null &&
+        v !== undefined &&
+        v !== '' &&
+        !(Array.isArray(v) && v.length === 0) &&
+        !(typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0)
+      )
+    ).toBe(true);
+  }
+
+async function getNewPumpFunToken(p: GrpcProvider): Promise<GetPumpFunNewTokensStreamResponse> {
+    const request = {} as GetPumpFunNewTokensStreamRequest;
+    try {
+        const stream = await p.getPumpFunNewTokensStream(request);
+        for await (const response of stream) {
+            return response;
+        }
+        throw new Error("No response received from token stream");
+    } catch (error) {
+        console.error("Error getting new pump fun token:", error);
+        throw error;
+    }
+}
 
 describe('Transaction Submissions', () => {
     let config: ReturnType<typeof loadFromEnv>;
     let provider: InstanceType<typeof GrpcProvider>; 
+    let pump_provider: InstanceType<typeof GrpcProvider>; 
     let signer: InstanceType<typeof Keypair>; 
     let bloxrouteTipWallet: InstanceType<typeof PublicKey>;
     let jitoTipWallet: InstanceType<typeof PublicKey>;
@@ -36,6 +80,12 @@ describe('Transaction Submissions', () => {
             `${MAINNET_API_NY_GRPC}:${MAINNET_API_GRPC_PORT}`,
             true
         );
+        pump_provider = new GrpcProvider(
+            config.authHeader,
+            config.privateKey,
+            `${MAINNET_API_NY_GRPC}:${MAINNET_API_GRPC_PORT}`,
+            true
+        )
         signer = Keypair.fromSecretKey(
             bs58.decode(config.privateKey)
         )
@@ -159,37 +209,37 @@ describe('Transaction Submissions', () => {
     test('PostSubmit', async () => {
         // Create transaction and request using helper functions
         const transaction = await createSignedTransactionWithBloXrouteTip({computeLimit: 500_000, priorityFee: 1_000, bloxrouteTip: 1_000_000});
-        const postSubmitRequest = createPostSubmitRequest(transaction);
+        const request = createPostSubmitRequest(transaction);
 
         // Submit transaction
-        const postSubmitResponse = await provider.postSubmit(postSubmitRequest);
-        console.info(JSON.stringify(postSubmitResponse, null, 2));
+        const response = await provider.postSubmit(request);
+        console.info(JSON.stringify(response, null, 2));
 
-        expect(postSubmitResponse.signature);
+        expectNoNulls(response)
     });
 
     test('PostSubmitV2', async () => {
         // Create transaction and request using helper functions
         const transaction = await createSignedTransactionWithBloXrouteTip({computeLimit: 500_000, priorityFee: 1_000, bloxrouteTip: 1_000_000});
-        const postSubmitRequest = createPostSubmitRequest(transaction);
+        const request = createPostSubmitRequest(transaction);
 
         // Submit transaction using V2
-        const postSubmitResponse = await provider.postSubmitV2(postSubmitRequest);
-        console.info(JSON.stringify(postSubmitResponse, null, 2));
+        const response = await provider.postSubmitV2(request);
+        console.info(JSON.stringify(response, null, 2));
 
-        expect(postSubmitResponse.signature);
+        expectNoNulls(response)
     });
 
     test('PostSubmitPaladinV2', async () => {
         // Create transaction and request using helper functions
         const transaction = await createSignedTransactionWithBloXrouteTip({computeLimit: 1_000_000, priorityFee: 40_000_000, bloxrouteTip: 10_000_000});
-        const postSubmitRequest = createPostSubmitPaladinRequest(transaction);
+        const request = createPostSubmitPaladinRequest(transaction);
 
         // Submit transaction using V2
-        const postSubmitResponse = await provider.postSubmitPaladinV2(postSubmitRequest);
-        console.info(JSON.stringify(postSubmitResponse, null, 2));
+        const response = await provider.postSubmitPaladinV2(request);
+        console.info(JSON.stringify(response, null, 2));
 
-        expect(postSubmitResponse.signature);
+        expectNoNulls(response)
     });
 
     test('PostSubmitSnipeV2', async () => {
@@ -197,17 +247,202 @@ describe('Transaction Submissions', () => {
         const transactions = await createSnipeTransactions({computeLimit: 500_000, priorityFee: 1_000, bloxrouteTip: 1_000_000, jitoTip: 100_000});
         
         // Create snipe request
-        const snipeRequest = createPostSubmitSnipeRequest(transactions);
+        const request = createPostSubmitSnipeRequest(transactions);
         
         // Submit snipe request
-        const snipeResponse = await provider.postSubmitSnipeV2(snipeRequest);
-        console.info(JSON.stringify(snipeResponse, null, 2));
+        const response = await provider.postSubmitSnipeV2(request);
+        console.info(JSON.stringify(response, null, 2));
         
         // Expect at least one signature in the response
-        expect(snipeResponse.transactions.length).toBeGreaterThan(0);
-        for (const tx of snipeResponse.transactions) {
-            expect(tx.error).toBe("");
-        }
+        expectNoNulls(response)
     });
+
+    test("PostPumpFunSwapSol", async () => {
+        const token: GetPumpFunNewTokensStreamResponse = await getNewPumpFunToken(pump_provider)
+        console.info(JSON.stringify(token, null, 2))
+        const request: PostPumpFunSwapRequestSol = {
+            userAddress: token.creator,
+            bondingCurveAddress: token.bondingCurve,
+            tokenAddress: token.mint,
+            solAmount: 0.0001,
+            slippage: 20,
+            computeLimit: 250_000,
+            computePrice: "100000",
+            tip: "1000000"
+        }
+        const response = await pump_provider.postPumpFunSwapSol(request)
+        console.info(JSON.stringify(response, null, 2))
+        expectNoNulls(response)
+    })
     
 });
+
+describe('Streaming', () => {
+    let config: ReturnType<typeof loadFromEnv>;
+    let provider: InstanceType<typeof GrpcProvider>; 
+    let pump_provider: InstanceType<typeof GrpcProvider>; 
+
+    // Run before each test
+    beforeEach(() => {
+        config = loadFromEnv();
+        provider = new GrpcProvider(
+            config.authHeader,
+            config.privateKey,
+            `${MAINNET_API_NY_GRPC}:${MAINNET_API_GRPC_PORT}`,
+            true
+        );
+        pump_provider = new GrpcProvider(
+            config.authHeader,
+            config.privateKey,
+            `${LOCAL_API_GRPC_HOST}:${LOCAL_API_GRPC_PORT}`,
+            true
+        )
+    });
+
+    /*
+    General Streams
+    */
+    test('Stream Recent Blockhash', async () => {
+        const request = {} as GetRecentBlockHashRequest
+        const stream = await provider.getRecentBlockHashStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    test('Stream Priority Fee', async () => {
+        const request = {} as GetPriorityFeeRequest
+        const stream = await provider.getPriorityFeeStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    test('Stream Bundle Tip', async () => {
+        const request = {} as GetBundleTipRequest
+        const stream = await provider.getBundleTipStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    /*
+    PumpFun Streams
+    */
+
+    test('Stream New PumpSwap AMM Pools', async () => {
+        const request = {} as GetPumpFunNewAmmPoolStreamRequest
+        const stream = await pump_provider.getPumpFunNewAmmPoolStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    }, 60000);
+
+    test('Stream New PumpFun Tokens', async () => {
+        const request = {} as GetPumpFunNewTokensStreamRequest
+        const stream = await pump_provider.getPumpFunNewTokensStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    }, 30000);
+
+    test('Stream New Pump Fun Swaps', async () => {
+        const newToken = await getNewPumpFunToken(pump_provider)
+        const request = {
+            tokens: [newToken.mint]
+        } as GetPumpFunSwapsStreamRequest
+        const stream = await pump_provider.getPumpFunSwapsStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    }, 30000);
+
+    /*
+    Raydium Streams
+    */
+
+    test('Stream New Raydium Pools', async () => {
+        const request = {} as GetPumpFunNewAmmPoolStreamRequest
+        const stream = await provider.getNewRaydiumPoolsStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    }, 86_400_000);
+
+    test('Stream New Raydium Pools By Transaction', async () => {
+        const request = {} as GetNewRaydiumPoolsByTransactionRequest
+        const stream = await provider.getNewRaydiumPoolsByTransactionStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    }, 86_400_000);
+
+});
+
+describe("Requests", () => {
+    let config: ReturnType<typeof loadFromEnv>;
+    let provider: InstanceType<typeof GrpcProvider>; 
+    let pump_provider: InstanceType<typeof GrpcProvider>; 
+
+    // Run before each test
+    beforeEach(() => {
+        config = loadFromEnv();
+        provider = new GrpcProvider(
+            config.authHeader,
+            config.privateKey,
+            `${LOCAL_API_GRPC_HOST}:${LOCAL_API_GRPC_PORT}`,
+            false
+        );
+        pump_provider = new GrpcProvider(
+            config.authHeader,
+            config.privateKey,
+            `${LOCAL_API_GRPC_HOST}:${LOCAL_API_GRPC_PORT}`,
+            false
+        )
+    });
+
+    test("Get Account", async () => {
+        const response = await provider.getTokenAccounts(
+            {
+                ownerAddress: "AfU4AhJhqSsMji1oij1ZGfskQGGmmUW1vsdS3j7eeEwj"
+            } as GetTokenAccountsRequest
+        )
+        console.info(JSON.stringify(response, null, 2))
+        expectNoNulls(response)
+    });
+
+    test("Get Priority Fee", async () => {
+        const response = await provider.getPriorityFee(
+            {
+                project: "P_RAYDIUM",
+                percentile: 50
+            } as GetPriorityFeeRequest
+        )
+        console.info(JSON.stringify(response, null, 2))
+        expectNoNulls(response)
+    });
+})

--- a/tests/integration/grpc.test.ts
+++ b/tests/integration/grpc.test.ts
@@ -32,6 +32,7 @@ import { LOCAL_API_GRPC_HOST, LOCAL_API_GRPC_PORT, MAINNET_API_PUMP_NY_GRPC } fr
 
 jest.setTimeout(60500);
 
+// eslint-disable-next-line
 function expectNoNulls(response: any) {
     const { timestamp, ...responseWithoutTimestamp } = response;
     

--- a/tests/integration/grpc.test.ts
+++ b/tests/integration/grpc.test.ts
@@ -18,9 +18,6 @@ import {
     GetBundleTipRequest,
     GetTokenAccountsRequest,
     GetPumpFunNewTokensStreamResponse,
-    GetPoolReservesStreamRequest,
-    Project,
-    GetLeaderScheduleRequest,
     PostPumpFunSwapRequestSol
 } from "../../bxsolana";
 import bs58 from 'bs58'
@@ -83,7 +80,7 @@ describe('Transaction Submissions', () => {
         pump_provider = new GrpcProvider(
             config.authHeader,
             config.privateKey,
-            `${MAINNET_API_NY_GRPC}:${MAINNET_API_GRPC_PORT}`,
+            `${MAINNET_API_PUMP_NY_GRPC}:${MAINNET_API_GRPC_PORT}`,
             true
         )
         signer = Keypair.fromSecretKey(

--- a/tests/integration/http.test.ts
+++ b/tests/integration/http.test.ts
@@ -26,6 +26,7 @@ import { MAINNET_API_PUMP_NY_HTTP } from "../../bxsolana/utils/constants";
 
 jest.setTimeout(60500);
 
+// eslint-disable-next-line
 function expectNoNulls(response: any) {
     const { timestamp, ...responseWithoutTimestamp } = response;
     

--- a/tests/integration/http.test.ts
+++ b/tests/integration/http.test.ts
@@ -9,6 +9,10 @@ import {
     PostSubmitPaladinRequest,
     PostSubmitRequestEntry,
     PostSubmitSnipeRequest,
+    GetPumpFunNewTokensStreamRequest,
+    GetPriorityFeeRequest,
+    GetTokenAccountsRequest,
+    GetPumpFunNewTokensStreamResponse,
 } from "../../bxsolana";
 import bs58 from 'bs58'
 import {
@@ -18,6 +22,37 @@ import {
     Transaction,
     ComputeBudgetProgram,
   } from '@solana/web3.js';
+import { MAINNET_API_PUMP_NY_HTTP } from "../../bxsolana/utils/constants";
+
+jest.setTimeout(60500);
+
+function expectNoNulls(response: any) {
+    const { timestamp, ...responseWithoutTimestamp } = response;
+    
+    expect(
+      Object.values(responseWithoutTimestamp).every(v =>
+        v !== null &&
+        v !== undefined &&
+        v !== '' &&
+        !(Array.isArray(v) && v.length === 0) &&
+        !(typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0)
+      )
+    ).toBe(true);
+  }
+
+async function getNewPumpFunToken(p: HttpProvider): Promise<GetPumpFunNewTokensStreamResponse> {
+    const request = {} as GetPumpFunNewTokensStreamRequest;
+    try {
+        const stream = await p.getPumpFunNewTokensStream(request);
+        for await (const response of stream) {
+            return response;
+        }
+        throw new Error("No response received from token stream");
+    } catch (error) {
+        console.error("Error getting new pump fun token:", error);
+        throw error;
+    }
+}
 
 describe('Transaction Submissions', () => {
     let config: ReturnType<typeof loadFromEnv>;
@@ -209,3 +244,40 @@ describe('Transaction Submissions', () => {
     });
     
 });
+
+
+describe("Requests", () => {
+    let config: ReturnType<typeof loadFromEnv>;
+    let provider: InstanceType<typeof HttpProvider>; 
+
+    // Run before each test
+    beforeEach(() => {
+        config = loadFromEnv();
+        provider = new HttpProvider(
+            config.authHeader,
+            config.privateKey,
+            `${MAINNET_API_NY_HTTP}`
+        );
+    });
+
+    test("Get Account", async () => {
+        const response = await provider.getTokenAccounts(
+            {
+                ownerAddress: "AfU4AhJhqSsMji1oij1ZGfskQGGmmUW1vsdS3j7eeEwj"
+            } as GetTokenAccountsRequest
+        )
+        console.info(JSON.stringify(response, null, 2))
+        expectNoNulls(response)
+    });
+
+    test("Get Priority Fee", async () => {
+        const response = await provider.getPriorityFee(
+            {
+                project: "P_RAYDIUM",
+                percentile: 50
+            } as GetPriorityFeeRequest
+        )
+        console.info(JSON.stringify(response, null, 2))
+        expectNoNulls(response)
+    });
+})

--- a/tests/integration/ws.test.ts
+++ b/tests/integration/ws.test.ts
@@ -8,7 +8,15 @@ import {
     TransactionMessageV2,
     PostSubmitPaladinRequest,
     PostSubmitRequestEntry,
-    PostSubmitSnipeRequest
+    PostSubmitSnipeRequest,
+    GetPumpFunNewAmmPoolStreamRequest,
+    GetPumpFunNewTokensStreamRequest,
+    GetPumpFunSwapsStreamRequest,
+    GetNewRaydiumPoolsByTransactionRequest,
+    GetPriorityFeeRequest,
+    GetBundleTipRequest,
+    GetTokenAccountsRequest,
+    GetPumpFunNewTokensStreamResponse,
 } from "../../bxsolana";
 import bs58 from 'bs58'
 import {
@@ -18,6 +26,37 @@ import {
     Transaction,
     ComputeBudgetProgram,
   } from '@solana/web3.js';
+import { MAINNET_API_PUMP_NY_WS } from "../../bxsolana/utils/constants";
+
+jest.setTimeout(60500);
+
+function expectNoNulls(response: any) {
+    const { timestamp, ...responseWithoutTimestamp } = response;
+    
+    expect(
+      Object.values(responseWithoutTimestamp).every(v =>
+        v !== null &&
+        v !== undefined &&
+        v !== '' &&
+        !(Array.isArray(v) && v.length === 0) &&
+        !(typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0)
+      )
+    ).toBe(true);
+  }
+
+async function getNewPumpFunToken(p: WsProvider): Promise<GetPumpFunNewTokensStreamResponse> {
+    const request = {} as GetPumpFunNewTokensStreamRequest;
+    try {
+        const stream = await p.getPumpFunNewTokensStream(request);
+        for await (const response of stream) {
+            return response;
+        }
+        throw new Error("No response received from token stream");
+    } catch (error) {
+        console.error("Error getting new pump fun token:", error);
+        throw error;
+    }
+}
 
 describe('Transaction Submissions', () => {
     let config: ReturnType<typeof loadFromEnv>;
@@ -212,5 +251,174 @@ describe('Transaction Submissions', () => {
             expect(tx.error).toBe("");
         }
     });
-    
 });
+
+describe('Streaming', () => {
+    let config: ReturnType<typeof loadFromEnv>;
+    let provider: InstanceType<typeof WsProvider>; 
+    let pump_provider: InstanceType<typeof WsProvider>; 
+
+    // Run before each test
+    beforeEach(async () => {
+        config = loadFromEnv();
+        provider = new WsProvider(
+            config.authHeader,
+            config.privateKey,
+            `${MAINNET_API_NY_WS}`,
+        );
+        pump_provider = new WsProvider(
+            config.authHeader,
+            config.privateKey,
+            `${MAINNET_API_PUMP_NY_WS}`,
+        )
+        await provider.connect();
+        await pump_provider.connect();
+    });
+
+    /*
+    General Streams
+    */
+    test('Stream Recent Blockhash', async () => {
+        const request = {} as GetRecentBlockHashRequest
+        const stream = await provider.getRecentBlockHashStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    test('Stream Priority Fee', async () => {
+        const request = {} as GetPriorityFeeRequest
+        const stream = await provider.getPriorityFeeStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    test('Stream Bundle Tip', async () => {
+        const request = {} as GetBundleTipRequest
+        const stream = await provider.getBundleTipStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    /*
+    PumpFun Streams
+    */
+
+    test('Stream New PumpSwap AMM Pools', async () => {
+        const request = {} as GetPumpFunNewAmmPoolStreamRequest
+        const stream = await pump_provider.getPumpFunNewAmmPoolStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    test('Stream New PumpFun Tokens', async () => {
+        const request = {} as GetPumpFunNewTokensStreamRequest
+        const stream = await pump_provider.getPumpFunNewTokensStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    test('Stream New Pump Fun Swaps', async () => {
+        const newToken = await getNewPumpFunToken(pump_provider)
+        const request = {
+            tokens: [newToken.mint]
+        } as GetPumpFunSwapsStreamRequest
+        const stream = await pump_provider.getPumpFunSwapsStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    /*
+    Raydium Streams
+    */
+
+    test('Stream New Raydium Pools', async () => {
+        const request = {} as GetPumpFunNewAmmPoolStreamRequest
+        const stream = await provider.getNewRaydiumPoolsStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+    test('Stream New Raydium Pools By Transaction', async () => {
+        const request = {} as GetNewRaydiumPoolsByTransactionRequest
+        const stream = await provider.getNewRaydiumPoolsByTransactionStream(request)
+
+        for await (const response of stream) {
+            console.info(JSON.stringify(response, null, 2))
+            expectNoNulls(response)
+            break
+        }
+    });
+
+});
+
+describe("Requests", () => {
+    let config: ReturnType<typeof loadFromEnv>;
+    let provider: InstanceType<typeof WsProvider>; 
+    let pump_provider: InstanceType<typeof WsProvider>; 
+
+    // Run before each test
+    beforeEach(async () => {
+        config = loadFromEnv();
+        provider = new WsProvider(
+            config.authHeader,
+            config.privateKey,
+            `${MAINNET_API_NY_WS}`,
+        );
+        pump_provider = new WsProvider(
+            config.authHeader,
+            config.privateKey,
+            `${MAINNET_API_PUMP_NY_WS}`,
+        )
+        await provider.connect();
+        await pump_provider.connect();
+    });
+
+    test("Get Account", async () => {
+        const response = await provider.getTokenAccounts(
+            {
+                ownerAddress: "AfU4AhJhqSsMji1oij1ZGfskQGGmmUW1vsdS3j7eeEwj"
+            } as GetTokenAccountsRequest
+        )
+        console.info(JSON.stringify(response, null, 2))
+        expectNoNulls(response)
+    });
+
+    test("Get Priority Fee", async () => {
+        const response = await provider.getPriorityFee(
+            {
+                project: "P_RAYDIUM",
+                percentile: 50
+            } as GetPriorityFeeRequest
+        )
+        console.info(JSON.stringify(response, null, 2))
+        expectNoNulls(response)
+    });
+})

--- a/tests/integration/ws.test.ts
+++ b/tests/integration/ws.test.ts
@@ -30,6 +30,7 @@ import { MAINNET_API_PUMP_NY_WS } from "../../bxsolana/utils/constants";
 
 jest.setTimeout(60500);
 
+// eslint-disable-next-line
 function expectNoNulls(response: any) {
     const { timestamp, ...responseWithoutTimestamp } = response;
     


### PR DESCRIPTION
### Summary of Changes

- **Added `sdk.ts`**  
  A demonstration file showcasing user interactions with our SDKs. It includes coverage of streaming, transaction, and system request calls across all three providers: gRPC, HTTP, and WebSocket.

- **Updated Developer Dependencies**  
  Added required packages used by the SDK.

- **Replaced `npm start` Script**  
  The default `start` script now runs the `sdk.ts` example.

- **Enhanced Test Coverage**  
  Added Jest integration tests covering the new SDK functionality and provider-specific calls.
  
  
![Screenshot 2025-04-22 at 3 49 05 PM](https://github.com/user-attachments/assets/22519743-f09e-4397-87c7-c4a96d88111b)



